### PR TITLE
Update Ruth Epoch IFP address

### DIFF
--- a/src/consensus/addresses.h
+++ b/src/consensus/addresses.h
@@ -143,7 +143,7 @@ Consensus::CoinbaseAddresses AddressSets = {
         },
     .ruth =
         {
-            "lotus_16PSJMaps9sQg7aBQgyY1RdHb2fZYdmWhQPbgus75"
+            "lotus_16PSJPi88MtH34Ti3dZza4MFRF9XUVd3fKc6Ec3TV"
         }
 };
 } // namespace RewardAddresses

--- a/test/functional/logos_feature_minerfund_activation.py
+++ b/test/functional/logos_feature_minerfund_activation.py
@@ -128,7 +128,7 @@ JUDGES_SCRIPTS = [
     "76a9149208ecc785c92968481a92aee7024b77e54d27dc88ac",
 ]
 RUTH_SCRIPTS = [
-    "76a9149208ecc785c92968481a92aee7024b77e54d27dc88ac",
+    "76a914d7756030f4292b70cb70dc4df231b14109c6806188ac",
 ]
 
 class MinerFundActivationTest(BitcoinTestFramework):


### PR DESCRIPTION
Previous v8.3.3 implementation used the same IFP address from the Judges Epoch, but a new address is necessary in order to determine the fork block into the Ruth Epoch. This commit adds a new IFP address for this purpose.