### PR TITLE
Ensure that the Uncache method in CCoinsViewCache is properly impleme…

### DIFF
--- a/contrib/utils/install-dependencies.sh
+++ b/contrib/utils/install-dependencies.sh
@@ -95,7 +95,7 @@ BACKPORTS=(
   shellcheck
 )
 
-echo "deb http://deb.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list
+echo "deb http://archive.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -t buster-backports install -y $(join_by ' ' "${BACKPORTS[@]}")
 


### PR DESCRIPTION
…nted.

This change ensures that the Uncache method in CCoinsViewCache properly removes UTXOs from the cache only if they are not modified. This is important to prevent memory DoS in case we receive a large number of invalid transactions that attempt to overrun the in-memory coins cache (CCoinsViewCache::cacheCoins).