### PR TITLE
Move the Uncache method to the CCoinsViewCache class.

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -276,8 +276,10 @@ bool CCoinsViewCache::Flush() {
 }
 
 void CCoinsViewCache::Uncache(const COutPoint &outpoint) {
-    CCoinsMap::iterator it = cacheCoins.find(outpoint);
-    if (it != cacheCoins.end() && it->second.flags == 0) {
+    auto it = cacheCoins.find(outpoint);
+    if (it != cacheCoins.end() &&
+        !(it->second.flags & CCoinsCacheEntry::DIRTY)) {
+        // Only remove if the entry is not dirty (hasn't been modified)
         cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
         cacheCoins.erase(it);
     }

--- a/src/coins.h
+++ b/src/coins.h
@@ -306,15 +306,7 @@ public:
      * number of invalid transactions that attempt to overrun the in-memory
      * coins cache (CCoinsViewCache::cacheCoins).
      */
-    void Uncache(const COutPoint &outpoint) {
-        auto it = cacheCoins.find(outpoint);
-        if (it != cacheCoins.end() &&
-            !(it->second.flags & CCoinsCacheEntry::DIRTY)) {
-            // Only remove if the entry is not dirty (hasn't been modified)
-            cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
-            cacheCoins.erase(it);
-        }
-    }
+    void Uncache(const COutPoint &outpoint);
 
     //! Calculate the size of the cache (in number of transaction outputs)
     unsigned int GetCacheSize() const;


### PR DESCRIPTION
Don't implement Uncache method in the header file, but adjust the current implementation in the CCoinsViewCache class.

Fixes build issue in #20 