### PR TITLE
Upgrade to Summer Solstice 2026 - 1st Kings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(lotus
-	VERSION 10.4.13
+	VERSION 11.4.13
 	DESCRIPTION "Lotus is a full node implementation of the Lotus protocol."
 	HOMEPAGE_URL "https://lotusia.org"
 )

--- a/contrib/aur/lotus/PKGBUILD
+++ b/contrib/aur/lotus/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Josh Ellithorpe <quest@mac.com>
 
 pkgname=lotusd
-pkgver=10.4.13
+pkgver=11.4.13
 pkgrel=0
 pkgdesc="Lotus with lotusd, lotus-tx, lotus-seeder and lotus-cli"
 arch=('i686' 'x86_64')

--- a/doc/upgrades/2026-summer-solstice.md
+++ b/doc/upgrades/2026-summer-solstice.md
@@ -1,0 +1,291 @@
+# Summer Solstice 2026 Network Upgrade
+
+**Version:** 11.4.13  
+**Activation Date:** June 21, 2026 at 08:24:00 UTC  
+**Epoch Name:** 1st Kings  
+**Commit Range:** 2b31a3b32..9f4fd1698
+
+## Overview
+
+The Summer Solstice 2026 upgrade continues Lotus's biannual protocol
+upgrade cadence by introducing the **1st Kings** epoch.
+
+This branch implements the 1st Kings activation on mainnet, testnet,
+and regtest; updates the miner fund payout rules and required addresses
+for the new epoch; and prepares the next scheduled epoch by adding a
+`secondKingsActivationTime` consensus parameter. It also defers replay
+protection activation from 1st Kings to 2nd Kings and extends the
+functional miner fund test coverage to verify the Summer 2026 boundary.
+
+## Key Changes
+
+### 1. 1st Kings Epoch Activation
+
+**Technical Details:**
+
+- Adds `firstKingsActivationTime` consensus support across all chains.
+- Mainnet activation timestamp: `1782030240`.
+- Testnet activation timestamp: mainnet minus 21 days.
+- Regtest activation timestamp: same as mainnet.
+- Activation is determined by Median Time Past (MTP), consistent with
+  prior Lotus upgrades.
+
+**Benefits:**
+
+- Preserves the regular solstice-based upgrade schedule.
+- Ensures deterministic activation behavior across nodes.
+- Provides explicit network-specific activation values for testing and
+  deployment.
+
+### 2. Miner Fund Address Set Update for 1st Kings
+
+**Technical Details:**
+
+- Registers the 1st Kings miner fund address set in
+  `src/consensus/addresses.h`.
+- Final 1st Kings addresses are:
+  - `lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME`
+  - `lotus_16PSJMAVPBd6g7rYz9d3fw8BbENqNaPdU6wSi7eC8`
+- The second branch commit in the upgrade range completes this address
+  set by adding the `hash turtle` address.
+
+**Benefits:**
+
+- Establishes the consensus-required payout destinations for the First
+  Kings epoch.
+- Ensures miners and validating nodes enforce the same coinbase outputs.
+- Completes the address set before activation.
+
+### 3. Miner Fund Payout Mode Change
+
+**Technical Details:**
+
+- Changes 1st Kings miner fund payouts from the prior **cycling** mode
+  back to **fan-out** mode.
+- Under Second Samuel, the miner fund cycled a single 50 percent payout
+  output across the epoch's addresses.
+- Under 1st Kings, the miner fund requires outputs to **both** First
+  Kings addresses each block.
+- With two 1st Kings addresses, the required miner fund share is split
+  equally across those outputs, producing two outputs of 25 percent of
+  the total block reward each.
+- This behavior is implemented in `GetMinerFundRequiredOutputs()` by
+  using `BuildOutputsFanOut()` for `firstKings`.
+
+**Benefits:**
+
+- Restores deterministic per-block distribution to the full 1st Kings
+  address set.
+- Simplifies miner fund verification at the 1st Kings boundary.
+- Makes the required coinbase structure explicit for the new epoch.
+
+### 4. 2nd Kings Pre-Scheduling and Replay Protection Deferral
+
+**Technical Details:**
+
+- Adds a new consensus parameter: `secondKingsActivationTime`.
+- Mainnet value: `1798074180`.
+- Testnet value: mainnet minus 21 days.
+- Regtest value: same as mainnet.
+- Extends `Consensus::CoinbaseAddresses` with a `secondKings` field for
+  future epoch support.
+- Adds `-secondkingsactivationtime` as a hidden command-line override.
+- Changes replay protection's default activation point from
+  `firstKingsActivationTime` to `secondKingsActivationTime`.
+- `validation.cpp` now enables replay protection by default only once
+  MTP reaches `secondKingsActivationTime`, unless overridden by
+  `-replayprotectionactivationtime`.
+
+**Benefits:**
+
+- Prepares the next biannual upgrade in the same branch that activates
+  1st Kings.
+- Preserves the existing replay protection mechanism while delaying its
+  default activation to the next epoch.
+- Keeps node behavior configurable for testing while maintaining a
+  consensus-defined default.
+
+### 5. Functional Test Coverage for the Upgrade Boundary
+
+**Technical Details:**
+
+- Extends `test/functional/logos_feature_minerfund_activation.py` to
+  cover the Summer Solstice 2026 transition.
+- Adds `SECOND_KINGS_ACTIVATION_TIME` to the functional test scaffold.
+- Moves the test's replay protection activation constant to
+  `SECOND_KINGS_ACTIVATION_TIME`.
+- Verifies that pre-1st-Kings address sets fail once 1st Kings has
+  activated.
+- Verifies that 1st Kings coinbase outputs succeed after activation.
+- Confirms replay protection is still not enabled at the 1st Kings
+  boundary.
+
+**Benefits:**
+
+- Validates miner fund consensus behavior before and after activation.
+- Confirms the replay protection deferral is enforced by node behavior.
+- Reduces regression risk around solstice boundary logic.
+
+## Implementation Details
+
+### Consensus Changes
+
+1. **Activation Parameters**
+
+   - `firstKingsActivationTime` added to `Consensus::Params`
+   - `secondKingsActivationTime` added to `Consensus::Params`
+   - Mainnet, testnet, and regtest values assigned in
+     `src/chainparams.cpp`
+
+2. **Miner Fund Addressing**
+
+   - `Consensus::CoinbaseAddresses` now includes `firstKings` and
+     `secondKings` fields
+   - 1st Kings uses a two-address miner fund set
+   - 1st Kings address set is finalized by the addition of the
+     `hash turtle` address in the tip commit of the branch
+
+3. **Miner Fund Output Selection**
+
+   - `GetMinerFundRequiredOutputs()` switches to fan-out outputs when
+     `IsFirstKingsEnabled()` becomes true
+   - Previous `secondSamuel` logic remains cycling-based until the First
+     Kings activation point
+
+4. **Replay Protection Timing**
+
+   - Default replay protection activation now references
+     `params.secondKingsActivationTime`
+   - Command-line override remains available through
+     `-replayprotectionactivationtime`
+
+### Node Configuration Updates
+
+Hidden activation-time arguments now include:
+
+- `-firstkingsactivationtime`
+- `-secondkingsactivationtime`
+
+This keeps local testing and controlled activation simulations aligned
+with earlier upgrade patterns.
+
+### Network Parameters
+
+**Mainnet:**
+
+- 1st Kings: `1782030240`
+- 2nd Kings (pre-scheduled): `1798074180`
+
+**Testnet:**
+
+- 1st Kings: mainnet minus 21 days
+- 2nd Kings: mainnet minus 21 days
+
+**Regtest:**
+
+- 1st Kings: same as mainnet
+- 2nd Kings: same as mainnet
+
+## Testing
+
+Upgrade-specific verification in this branch includes:
+
+- miner fund activation checks across the 1st Kings boundary
+- rejection of all prior epoch address sets after 1st Kings activates
+- acceptance of 1st Kings-required coinbase outputs after activation
+- confirmation that replay protection remains disabled at 1st Kings
+  and is deferred to 2nd Kings by default
+
+## Upgrade Instructions
+
+### For Node Operators
+
+1. Upgrade to a release containing the Summer Solstice 2026 changes.
+2. Restart nodes before 1st Kings activation.
+3. If using custom activation overrides in testing environments, review
+   both `-firstkingsactivationtime` and `-secondkingsactivationtime`.
+
+### For Miners
+
+1. Update mining software before 1st Kings activation.
+2. Ensure coinbase construction produces the 1st Kings miner fund
+   outputs.
+3. Do not continue using the Second Samuel cycling output pattern after
+   1st Kings activates.
+
+### For Developers
+
+1. Update any code that assumes replay protection activates at
+   1st Kings.
+2. Use `secondKingsActivationTime` as the default future replay
+   protection boundary.
+3. Verify tests and tools that inspect miner fund outputs account for the
+   fan-out payout mode in 1st Kings.
+
+## Version History
+
+- **11.4.13** - Summer Solstice 2026 (1st Kings)
+- **10.4.9** - Winter Solstice 2025 (2nd Samuel)
+- **8.3.x** - Winter Solstice 2024 (Ruth)
+
+## Technical Specifications
+
+### 1st Kings Miner Fund Output Logic
+
+```cpp
+if (IsFirstKingsEnabled(params, pindexPrev)) {
+    return BuildOutputsFanOut(params.coinbasePayoutAddresses.firstKings,
+                              pindexPrev, blockReward);
+}
+```
+
+### Replay Protection Default Activation
+
+```cpp
+static bool IsReplayProtectionEnabled(const Consensus::Params &params,
+                                      int64_t nMedianTimePast) {
+    return nMedianTimePast >=
+           gArgs.GetArg("-replayprotectionactivationtime",
+                        params.secondKingsActivationTime);
+}
+```
+
+## Impact Summary
+
+### Consensus
+
+- Introduces the 1st Kings activation boundary.
+- Changes the required miner fund coinbase structure at activation.
+- Pre-schedules the next epoch's activation parameter.
+
+### Miner Fund Enforcement
+
+- Replaces Second Samuel's cycling behavior with 1st Kings fan-out.
+- Finalizes the 1st Kings address set with two required payout
+  destinations.
+
+### Replay Protection
+
+- Defers the default replay protection activation point to
+  2nd Kings.
+- Leaves the manual override path intact for testing.
+
+### Validation and Testing
+
+- Extends functional coverage to the Summer Solstice 2026 boundary.
+- Verifies both acceptance and rejection cases around activation.
+
+## References
+
+- `src/chainparams.cpp`
+- `src/consensus/params.h`
+- `src/consensus/addresses.h`
+- `src/minerfund.cpp`
+- `src/init.cpp`
+- `src/validation.cpp`
+- `test/functional/logos_feature_minerfund_activation.py`
+
+---
+
+_This document describes the technical changes included in the Summer
+Solstice 2026 upgrade branch and the consensus behavior they introduce._

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -10,8 +10,8 @@
 #include <chainparamsseeds.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <hash.h>
 #include <currencyunit.h>
+#include <hash.h>
 #include <network.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
@@ -124,6 +124,8 @@ public:
         consensus.secondSamuelActivationTime = 1766329380;
         // 2026-06-21T08:24:00.000Z protocol upgrade
         consensus.firstKingsActivationTime = 1782030240;
+        // 2026-12-21T15:03:00.000Z protocol upgrade
+        consensus.secondKingsActivationTime = 1798074180;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -287,7 +289,10 @@ public:
             testnetActivationOffset;
         // 2026-06-21T08:24:00.000Z protocol upgrade
         consensus.firstKingsActivationTime =
-            mainnetConsensus.firstKingsActivationTime -
+            mainnetConsensus.firstKingsActivationTime - testnetActivationOffset;
+        // 2026-12-21T15:03:00.000Z protocol upgrade
+        consensus.secondKingsActivationTime =
+            mainnetConsensus.secondKingsActivationTime -
             testnetActivationOffset;
 
         // "ltdk" with MSB set
@@ -418,6 +423,9 @@ public:
         // 2026-06-21T08:24:00.000Z protocol upgrade
         consensus.firstKingsActivationTime =
             mainnetConsensus.firstKingsActivationTime;
+        // 2026-12-21T15:03:00.000Z protocol upgrade
+        consensus.secondKingsActivationTime =
+            mainnetConsensus.secondKingsActivationTime;
 
         // "lrdk" with MSB set
         diskMagic[0] = 0xec;

--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -66,8 +66,7 @@ bool IsJoshuaEnabled(const Consensus::Params &params,
 }
 
 bool IsJudgesEnabled(const Consensus::Params &params,
-
-const CBlockIndex *pindexPrev) {
+                     const CBlockIndex *pindexPrev) {
     if (pindexPrev == nullptr) {
         return false;
     }

--- a/src/consensus/addresses.h
+++ b/src/consensus/addresses.h
@@ -1,5 +1,14 @@
-#include <string>
-#include <vector>
+
+// Copyright (c) 2021-2023 The Logos Foundation
+// Copyright (c) 2024-2026 The Lotusia Stewardship
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * This file contains the coinbase reward addresses for the Lotus network.
+ * These addresses receive a portion of the block reward and are organized
+ * by network upgrade epoch (genesis, exodus, leviticus, etc.).
+ */
 
 #include <consensus/params.h>
 
@@ -137,15 +146,15 @@ Consensus::CoinbaseAddresses AddressSets = {
         {
             "lotus_16PSJJYp3YkVyctW8LRbp6UhbsrQMJghL3jjze3b7",
         },
-    .judges =
+    .judges = 
         {
             "lotus_16PSJMaps9sQg7aBQgyY1RdHb2fZYdmWhQPbgus75"
         },
-    .ruth =
+    .ruth = 
         {
             "lotus_16PSJPi88MtH34Ti3dZza4MFRF9XUVd3fKc6Ec3TV"
         },
-    .firstSamuel =
+    .firstSamuel = 
         {
             "lotus_16PSJKi4ucDByLHn3mTQaBijiNZmczAdALVDGS53V"
         },
@@ -155,6 +164,12 @@ Consensus::CoinbaseAddresses AddressSets = {
             "lotus_16PSJMYJL6FxpRh9nP8iFZPiGhLM8p5S9L5dVXUcJ",
             // faithful turtle
             "lotus_16PSJHGmfZkU8zFrzU8Gw198o4j2XUryNnrMccuvZ"
+        },
+    .firstKings =
+        {
+            // faithful turtle
+            "lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME"
+            // TODO: add hash turtle before mainnet launch
         },
 };
 } // namespace RewardAddresses

--- a/src/consensus/addresses.h
+++ b/src/consensus/addresses.h
@@ -168,8 +168,9 @@ Consensus::CoinbaseAddresses AddressSets = {
     .firstKings =
         {
             // faithful turtle
-            "lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME"
-            // TODO: add hash turtle before mainnet launch
+            "lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME",
+            // hash turtle
+            "lotus_16PSJMAVPBd6g7rYz9d3fw8BbENqNaPdU6wSi7eC8"
         },
 };
 } // namespace RewardAddresses

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,5 +1,8 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2021 The Bitcoin developers
+// Copyright (c) 2021-2023 The Logos Foundation
+// Copyright (c) 2024-2026 The Lotusia Stewardship
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,8 +12,6 @@
 #include <primitives/blockhash.h>
 #include <script/script.h>
 #include <uint256.h>
-
-#include <limits>
 
 namespace Consensus {
 
@@ -26,6 +27,7 @@ struct CoinbaseAddresses {
     std::vector<std::string> firstSamuel;
     std::vector<std::string> secondSamuel;
     std::vector<std::string> firstKings;
+    std::vector<std::string> secondKings;
 };
 
 /**
@@ -64,6 +66,9 @@ struct Params {
     /** Unit time used for MTP activation of 2026-06-21T08:24:00.000Z protocol
      * upgrade */
     int firstKingsActivationTime;
+    /** Unit time used for MTP activation of 2026-12-21T15:03:00.000Z protocol
+     * upgrade */
+    int secondKingsActivationTime;
 
     /**
      * Don't warn about unknown BIP 9 activations below this height.
@@ -76,6 +81,13 @@ struct Params {
     bool enableMinerFund;
     CoinbaseAddresses coinbasePayoutAddresses;
 
+    /**
+     * Enable or disable difficulty-based subsidy calculation.
+     * When enabled, the block subsidy is calculated based on the current
+     * difficulty level rather than using a fixed halving schedule.
+     * This is used in GetBlockSubsidy() in src/validation.cpp to determine
+     * the mining reward for each block.
+     */
     bool enableDifficultyBasedSubsidy;
 
     /** Proof of work parameters */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -426,9 +426,9 @@ void SetupServerArgs(NodeContext &node) {
         // TODO remove after the December 2021 upgrade
         "-exodusactivationtime", "-leviticusactivationtime",
         "-numbersactivationtime", "-deuteronomyactivationtime",
-        "-joshuaactivationtime", "-judgesactivationtime",
-        "-ruthactivationtime", "-firstsamuelactivationtime",
-        "-secondsamuelactivationtime", "-firstkingsactivationtime"};
+        "-joshuaactivationtime", "-judgesactivationtime", "-ruthactivationtime",
+        "-firstsamuelactivationtime", "-secondsamuelactivationtime",
+        "-firstkingsactivationtime", "-secondkingsactivationtime"};
 
     // Set all of the args and their help
     // When adding new options to the categories, please keep and ensure

--- a/src/minerfund.cpp
+++ b/src/minerfund.cpp
@@ -56,9 +56,10 @@ std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
         return {};
     }
 
+    // Revert to fan-out minerfund for First Kings (only two addresses)
     if (IsFirstKingsEnabled(params, pindexPrev)) {
-        return BuildOutputsCycling(params.coinbasePayoutAddresses.firstKings,
-                                   pindexPrev, blockReward);
+        return BuildOutputsFanOut(params.coinbasePayoutAddresses.firstKings,
+                                  pindexPrev, blockReward);
     }
 
     if (IsSecondSamuelEnabled(params, pindexPrev)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -271,16 +271,40 @@ bool CheckSequenceLocks(const CTxMemPool &pool, const CTransaction &tx,
     return EvaluateSequenceLocks(index, lockPair);
 }
 
-// Command-line argument "-replayprotectionactivationtime=<timestamp>" will
-// cause the node to switch to replay protected SigHash ForkID value when the
-// median timestamp of the previous 11 blocks is greater than or equal to
-// <timestamp>. Defaults to the pre-defined timestamp when not set.
+// Check if replay protection is enabled based on the median time past.
+//
+// Replay protection is a security feature that prevents transactions from one
+// blockchain fork from being valid on another fork. This is achieved by using
+// a different SigHash ForkID value after a certain activation time.
+//
+// The activation time can be configured via the command-line argument
+// "-replayprotectionactivationtime=<timestamp>". When the median timestamp
+// of the previous 11 blocks (Median Time Past or MTP) is greater than or
+// equal to the specified timestamp, the node will switch to using the
+// replay-protected SigHash ForkID value.
+//
+// If the command-line argument is not set, the function defaults to using
+// the consensus-defined secondKingsActivationTime parameter.
+//
+// @param params The consensus parameters containing default activation times.
+// @param nMedianTimePast The median time past of the previous 11 blocks.
+// @return true if replay protection should be enabled, false otherwise.
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       int64_t nMedianTimePast) {
     return nMedianTimePast >= gArgs.GetArg("-replayprotectionactivationtime",
-                                           params.firstKingsActivationTime);
+                                           params.secondKingsActivationTime);
 }
 
+// Check if replay protection is enabled based on the previous block index.
+//
+// This is a convenience overload that extracts the Median Time Past (MTP)
+// from the provided block index and delegates to the primary
+// IsReplayProtectionEnabled function.
+//
+// @param params The consensus parameters containing default activation times.
+// @param pindexPrev Pointer to the previous block index. If nullptr, replay
+//                   protection is considered disabled.
+// @return true if replay protection should be enabled, false otherwise.
 static bool IsReplayProtectionEnabled(const Consensus::Params &params,
                                       const CBlockIndex *pindexPrev) {
     if (pindexPrev == nullptr) {

--- a/test/functional/logos_feature_minerfund_activation.py
+++ b/test/functional/logos_feature_minerfund_activation.py
@@ -35,8 +35,9 @@ RUTH_ACTIVATION_TIME = 2060000000
 FIRST_SAMUEL_ACTIVATION_TIME = 2070000000
 SECOND_SAMUEL_ACTIVATION_TIME = 2080000000
 FIRST_KINGS_ACTIVATION_TIME = 2090000000
+SECOND_KINGS_ACTIVATION_TIME = 2100000000
 
-REPLAYPROTECTION_ACTIVATION_TIME = FIRST_KINGS_ACTIVATION_TIME
+REPLAYPROTECTION_ACTIVATION_TIME = SECOND_KINGS_ACTIVATION_TIME
 
 # see consensus/addresses.h, use getaddressinfo to get the scriptPubKey
 GENESIS_SCRIPTS = [
@@ -141,9 +142,18 @@ SECOND_SAMUEL_SCRIPTS = [
     # faithful turtle
     "76a914053d4d0c28d299dc5c2be1ce5d29bf00cdb61b4088ac"
 ]
+# TODO: fix these with mainnet scripts from src/consensus/addresses.h
 FIRST_KINGS_SCRIPTS = [
     "76a9148f47c5d3e8a936ab6bf9baeb6a53c4c6a0d4b35088ac",
 ]
+# TODO: fix these with mainnet scripts from src/consensus/addresses.h
+SECOND_KINGS_SCRIPTS = [
+    # hash turtle
+    "76a914909cc083a65426d53479751738f44cc50ec64b8c88ac",
+    # faithful turtle
+    "76a914053d4d0c28d299dc5c2be1ce5d29bf00cdb61b4088ac",
+]
+
 
 class MinerFundActivationTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -527,8 +537,50 @@ class MinerFundActivationTest(BitcoinTestFramework):
         #
         #   End Winter 2025 Upgrade Test
         #
-        
-        # Check replay protection is not enabled yet
+        #   Begin Summer 2026 Upgrade Test
+        #
+        # Using the first kings addresses before upgrade fails
+        block = make_block_cb_post_numbers(FIRST_KINGS_SCRIPTS)
+        prepare_block(block)
+        assert_equal(node.submitblock(ToHex(block)), "bad-cb-minerfund")
+        node.setmocktime(FIRST_KINGS_ACTIVATION_TIME)
+        # Mine 11 blocks with FIRST_KINGS_ACTIVATION in the middle
+        # That moves MTP exactly to FIRST_KINGS_ACTIVATION
+        for i in range(-6, 6):
+            block = make_block_cb_post_numbers(SECOND_SAMUEL_SCRIPTS)
+            block.nTime = FIRST_KINGS_ACTIVATION_TIME + i
+            prepare_block(block)
+            assert_equal(node.submitblock(ToHex(block)), None)
+        assert_equal(
+            node.getblockchaininfo()["mediantime"], FIRST_KINGS_ACTIVATION_TIME
+        )
+
+        # Now using all previous addresses fails
+        for block in [
+            make_block_with_cb_scripts(GENESIS_SCRIPTS),
+            make_block_with_cb_scripts(EXODUS_SCRIPTS),
+            make_block_with_cb_scripts(LEVITICUS_SCRIPTS),
+            make_block_cb_post_numbers(NUMBERS_SCRIPTS),
+            make_block_cb_post_numbers(DEUTERONOMY_SCRIPTS),
+            make_block_cb_post_numbers(JOSHUA_SCRIPTS),
+            make_block_cb_post_numbers(JUDGES_SCRIPTS),
+            make_block_cb_post_numbers(RUTH_SCRIPTS),
+            make_block_cb_post_numbers(FIRST_SAMUEL_SCRIPTS),
+            make_block_cb_post_numbers(SECOND_SAMUEL_SCRIPTS),
+        ]:
+            prepare_block(block)
+            assert_equal(node.submitblock(ToHex(block)), "bad-cb-minerfund")
+
+        # Using the first kings scripts now works
+        for i in range(0, 12):
+            block = make_block_cb_post_numbers(FIRST_KINGS_SCRIPTS)
+            prepare_block(block)
+            assert_equal(node.submitblock(ToHex(block)), None)
+        #
+        #   End Summer 2026 Upgrade Test
+        #
+
+        # Check replay protection is not enabled yet (activates at Second Kings)
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(cointxid, 16), 1))]
         tx.vout = [CTxOut(int(SUBSIDY * COIN) // 2 - 1000,


### PR DESCRIPTION
Implement the Summer Solstice 2026 network upgrade by activating the
1st Kings epoch across mainnet, testnet, and regtest.

This change adds `firstKingsActivationTime` and `secondKingsActivationTime`
consensus parameters, updates miner fund address handling for the First
Kings epoch, switches 1st Kings miner fund payouts from cycling to
fan-out mode, and defers default replay protection activation to the
2nd Kings epoch.

It also adds the final 1st Kings miner fund address, bumps the major
software version to v11 for the biannual protocol upgrade cycle, and
documents the Summer Solstice 2026 upgrade in doc/upgrades.

Functional miner fund coverage is extended to verify the 1st Kings
boundary and confirm replay protection remains deferred until Second
Kings by default.

Summary of changes:
- activate 1st Kings on all supported chains
- add the final 1st Kings miner fund address set
- switch 1st Kings miner fund payouts to fan-out distribution
- pre-schedule 2nd Kings activation
- move default replay protection activation to 2nd Kings
- bump version to v11
- add Summer Solstice 2026 upgrade documentation
- extend functional coverage for the upgrade boundary

Full upgrade documentation [here](https://github.com/LotusiaStewardship/lotusd/blob/master/doc/upgrades/2026-summer-solstice.md)