### PR TITLE
feat(nng): stratum mining RPCs and work-change pub/sub

### DIFF
--- a/doc/nng.md
+++ b/doc/nng.md
@@ -30,7 +30,7 @@ Likewise, PubSub messages are enabled using `-nngpub=<url>`, and `-nngpubmsg=<ms
  - `blkconnected` to notify when a block connected to the chain. Flatbuffers table is `BlockConnected`.
  - `blkdisconctd` to notify when a block disconnected from the chain (e.g. reorg, invalidateblock). Flatbuffers table is `BlockDisconnected`.
  - `chainstflush` to nofity when the block database has been flushed to the disk. Flatbuffers table is `ChainStateFlushed`.
-
+ - `miningworkchg` low-latency mining/template invalidation signal for external stratum services. Flatbuffers table is `MiningWorkChanged`.
 PubSub messages have their message type prepended as the first 12 bytes (0-padded if necessary), after that the message is encoded in the corresponding flatbuffers table (again, see [nng_interface.fbs](../src/nng_interface/nng_interface.fbs)).
 
 ## Example
@@ -44,6 +44,7 @@ nngpubmsg=blkconnected
 nngpubmsg=blkdisconctd
 nngpubmsg=mempooltxadd
 nngpubmsg=mempooltxrem
+nngpubmsg=miningworkchg
 ```
 
 The same urls would then be specified in the indexer to connect the node to it.

--- a/doc/nng.md
+++ b/doc/nng.md
@@ -56,3 +56,29 @@ In production, use whichever fits your topology:
   permissions provide the desired access control boundary.
 - `tcp://...` when stratum runs remotely; in this case, explicitly harden bind
   addresses and network policy (firewall allowlists, private networking, etc).
+
+### Mining endpoint examples
+
+IPC mode:
+
+```
+nngrpc=ipc://datadir/nngrpc.pipe
+nngpub=ipc://datadir/nngpub.pipe
+nngpubmsg=updateblktip
+nngpubmsg=miningworkchg
+```
+
+TCP mode:
+
+```
+nngrpc=tcp://127.0.0.1:52783
+nngpub=tcp://127.0.0.1:52784
+nngpubmsg=updateblktip
+nngpubmsg=miningworkchg
+```
+
+A Stratum coordinator typically subscribes to `miningworkchg` and calls:
+- `GetMiningTemplateRequest` on startup and on each work-change event
+- `ValidateMinedBlockProposalRequest` for optional pre-submit checks
+- `SubmitMinedBlockRequest` for solved candidates
+- `GetMiningStatusRequest` for operator health/state telemetry

--- a/doc/nng.md
+++ b/doc/nng.md
@@ -2,14 +2,25 @@
 
 This allows external indexers to be built efficiently using an easy to use NNG interface.
 
-RPC messages are enabled using `-nngrpc=<url>`, where `<url>` should start with tcp:// for a TCP bind, and with ipc:// for a named pipe file.
+RPC messages are enabled using `-nngrpc=<url>`, where `<url>` may be:
+- `tcp://...` for TCP bind/listen
+- `ipc://...` for local named pipe/socket
+
 Available RPC calls currently are:
  - `GetBlockRequest` to get an individual block
  - `GetBlockRangeRequest` to get a range of blocks
  - `GetBlockSliceRequest` to get a slice of a block
  - `GetUndoSliceRequest` to get a slice of the block undo data
  - `GetMempoolRequest` to get the node's mempool
+ - `GetMiningTemplateRequest` to fetch a native mining template optimized for external Stratum coordinators
+ - `SubmitMinedBlockRequest` to submit a solved block candidate from an external coordinator
+ - `ValidateMinedBlockProposalRequest` to pre-validate a candidate without requiring PoW (proposal semantics)
+ - `GetMiningStatusRequest` to fetch chain/mempool/high-level mining status fields
 
+The mining RPC additions are designed for external pooled-mining services and
+carry both consensus-level payloads (raw block/header bytes) and stratum-
+oriented convenience fields (coinbase split, merkle branches, endian-specific
+hex fields).
 Serialization of the objects transferred and further details are in [nng_interface.fbs](../src/nng_interface/nng_interface.fbs).
 
 Likewise, PubSub messages are enabled using `-nngpub=<url>`, and `-nngpubmsg=<msg>`, where `<msg>` is the message to be enabled (can be supplied more than once) and must be one of:
@@ -36,3 +47,11 @@ nngpubmsg=mempooltxrem
 ```
 
 The same urls would then be specified in the indexer to connect the node to it.
+
+For external stratum services, the exact same transport modes are supported.
+In production, use whichever fits your topology:
+
+- `ipc://...` when stratum and lotusd run on the same host and local filesystem
+  permissions provide the desired access control boundary.
+- `tcp://...` when stratum runs remotely; in this case, explicitly harden bind
+  addresses and network policy (firewall allowlists, private networking, etc).

--- a/doc/nng.md
+++ b/doc/nng.md
@@ -13,8 +13,6 @@ Available RPC calls currently are:
  - `GetUndoSliceRequest` to get a slice of the block undo data
  - `GetMempoolRequest` to get the node's mempool
  - `GetMiningTemplateRequest` to fetch a native mining template optimized for external Stratum coordinators
- - `SubmitMinedBlockRequest` to submit a solved block candidate from an external coordinator
- - `ValidateMinedBlockProposalRequest` to pre-validate a candidate without requiring PoW (proposal semantics)
  - `GetMiningStatusRequest` to fetch chain/mempool/high-level mining status fields
 
 The mining RPC additions are designed for external pooled-mining services and
@@ -30,7 +28,7 @@ Likewise, PubSub messages are enabled using `-nngpub=<url>`, and `-nngpubmsg=<ms
  - `blkconnected` to notify when a block connected to the chain. Flatbuffers table is `BlockConnected`.
  - `blkdisconctd` to notify when a block disconnected from the chain (e.g. reorg, invalidateblock). Flatbuffers table is `BlockDisconnected`.
  - `chainstflush` to nofity when the block database has been flushed to the disk. Flatbuffers table is `ChainStateFlushed`.
- - `miningworkchg` low-latency mining/template invalidation signal for external stratum services. Flatbuffers table is `MiningWorkChanged`.
+ - `miningwrkchg` low-latency mining/template invalidation signal for external stratum services. Flatbuffers table is `MiningWorkChanged`.
 PubSub messages have their message type prepended as the first 12 bytes (0-padded if necessary), after that the message is encoded in the corresponding flatbuffers table (again, see [nng_interface.fbs](../src/nng_interface/nng_interface.fbs)).
 
 ## Example
@@ -44,7 +42,7 @@ nngpubmsg=blkconnected
 nngpubmsg=blkdisconctd
 nngpubmsg=mempooltxadd
 nngpubmsg=mempooltxrem
-nngpubmsg=miningworkchg
+nngpubmsg=miningwrkchg
 ```
 
 The same urls would then be specified in the indexer to connect the node to it.
@@ -65,7 +63,7 @@ IPC mode:
 nngrpc=ipc://datadir/nngrpc.pipe
 nngpub=ipc://datadir/nngpub.pipe
 nngpubmsg=updateblktip
-nngpubmsg=miningworkchg
+nngpubmsg=miningwrkchg
 ```
 
 TCP mode:
@@ -74,11 +72,11 @@ TCP mode:
 nngrpc=tcp://127.0.0.1:52783
 nngpub=tcp://127.0.0.1:52784
 nngpubmsg=updateblktip
-nngpubmsg=miningworkchg
+nngpubmsg=miningwrkchg
 ```
 
-A Stratum coordinator typically subscribes to `miningworkchg` and calls:
+A Stratum coordinator typically subscribes to `miningwrkchg` and calls:
 - `GetMiningTemplateRequest` on startup and on each work-change event
-- `ValidateMinedBlockProposalRequest` for optional pre-submit checks
-- `SubmitMinedBlockRequest` for solved candidates
 - `GetMiningStatusRequest` for operator health/state telemetry
+
+Solved blocks are submitted via the JSON-RPC `submitblock` endpoint instead.

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -9,6 +9,7 @@
 #include <blockdb.h>
 #include <chainparams.h>
 #include <config.h>
+#include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <consensus/merkle.h>
 #include <hash.h>
@@ -871,6 +872,7 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
     NngInterface::Hash targetHash = CreateFbsHash(targetU256.begin());
 
     const uint64_t mintime = pindexPrev->GetMedianTimePast() + 1;
+    const uint64_t maxtime = GetAdjustedTime() + MAX_FUTURE_BLOCK_TIME;
 
     auto response = NngInterface::CreateGetMiningTemplateResponse(
         fbb, templateId,
@@ -878,8 +880,8 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
         fbb.CreateVector((const uint8_t *)headerStream.data(),
                          headerStream.size()),
         CreateFbsBlockHash(fbb, pblock->hashPrevBlock), pindexPrev->nHeight + 1,
-        pblock->nBits, &targetHash, pblock->GetBlockTime(),
-        mintime, coinbaseValue / SATOSHI,
+        pblock->nHeaderVersion, pblock->nBits, &targetHash,
+        pblock->GetBlockTime(), mintime, maxtime, coinbaseValue / SATOSHI,
         fbb.CreateVector((const uint8_t *)coinbaseStream.data(),
                          coinbaseStream.size()),
         fbb.CreateVector(txsFbs), fbb.CreateString(cb1), fbb.CreateString(cb2),
@@ -910,7 +912,8 @@ NngRpcErrorCode NngRpcServer::SubmitMinedBlock(
     if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
         auto resp = NngInterface::CreateSubmitMinedBlockResponse(
             fbb, NngInterface::MiningSubmitResult_INVALID_COINBASE, false,
-            fbb.CreateString("Block does not start with a coinbase"));
+            fbb.CreateString("Block does not start with a coinbase"),
+            CreateFbsBlockHash(fbb, BlockHash(block.GetHash())));
         fbb.Finish(resp);
         return NngRpcErrorCode::NO_RPC_ERROR;
     }
@@ -934,7 +937,8 @@ NngRpcErrorCode NngRpcServer::SubmitMinedBlock(
                            ? "duplicate-invalid"
                            : "duplicate-inconclusive");
             auto resp = NngInterface::CreateSubmitMinedBlockResponse(
-                fbb, code, false, fbb.CreateString(reason));
+                fbb, code, false, fbb.CreateString(reason),
+                CreateFbsBlockHash(fbb, BlockHash(hash)));
             fbb.Finish(resp);
             return NngRpcErrorCode::NO_RPC_ERROR;
         }
@@ -969,7 +973,8 @@ NngRpcErrorCode NngRpcServer::SubmitMinedBlock(
         result == NngInterface::MiningSubmitResult_ACCEPTED;
     const std::string reason = bip22Reason.has_value() ? *bip22Reason : "";
     auto resp = NngInterface::CreateSubmitMinedBlockResponse(
-        fbb, result, blockAccepted, fbb.CreateString(reason));
+        fbb, result, blockAccepted, fbb.CreateString(reason),
+        CreateFbsBlockHash(fbb, BlockHash(hash)));
     fbb.Finish(resp);
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
@@ -1056,6 +1061,7 @@ NngRpcServer::GetMiningStatus(flatbuffers::FlatBufferBuilder &fbb,
         fbb, CreateFbsBlockHash(fbb, tip->GetBlockHash()), tip->nHeight,
         ::ChainstateActive().IsInitialBlockDownload(),
         static_cast<uint64_t>(m_node.mempool->size()), peers,
+        GetAdjustedTime(), fbb.CreateString(tip->nChainWork.GetHex()),
         fbb.CreateString(GetConfig().GetChainParams().NetworkIDString()));
     fbb.Finish(resp);
     return NngRpcErrorCode::NO_RPC_ERROR;
@@ -1119,7 +1125,11 @@ private:
                 fbb, CreateFbsBlockHash(fbb, pindexNew->GetBlockHash())));
             BroadcastMessage(MSG_UPDATEBLKTIP, fbb);
         }
-        EmitMiningWorkChanged(NngInterface::MiningWorkChangeReason_NEW_TIP,
+        const bool reorg = pindexFork != nullptr &&
+                           pindexNew != nullptr &&
+                           pindexNew->pprev != pindexFork;
+        EmitMiningWorkChanged(reorg ? NngInterface::MiningWorkChangeReason_REORG
+                                    : NngInterface::MiningWorkChangeReason_NEW_TIP,
                               pindexNew);
     }
 
@@ -1143,7 +1153,7 @@ private:
                 tip = ::ChainActive().Tip();
             }
             EmitMiningWorkChanged(
-                NngInterface::MiningWorkChangeReason_MEMPOOL_UPDATE, tip);
+                NngInterface::MiningWorkChangeReason_MEMPOOL_REFRESH, tip);
         }
     }
 
@@ -1164,7 +1174,7 @@ private:
                 tip = ::ChainActive().Tip();
             }
             EmitMiningWorkChanged(
-                NngInterface::MiningWorkChangeReason_MEMPOOL_UPDATE, tip);
+                NngInterface::MiningWorkChangeReason_MEMPOOL_REFRESH, tip);
         }
     }
 

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -805,6 +805,12 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
         coinbaseScript = CScript() << OP_RETURN;
     }
 
+    std::vector<uint8_t> coinbaseIdentity;
+    if (request && request->coinbase_identity()) {
+        const auto &identityBytes = *request->coinbase_identity();
+        coinbaseIdentity.assign(identityBytes.begin(), identityBytes.end());
+    }
+
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     try {
         pblocktemplate = BlockAssembler(config, *m_node.mempool)
@@ -818,6 +824,25 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
     }
 
     CBlock *pblock = &pblocktemplate->block;
+
+    if (!coinbaseIdentity.empty()) {
+        CMutableTransaction coinbaseTx(*pblock->vtx[0]);
+        coinbaseTx.vin[0].scriptSig << coinbaseIdentity;
+
+        const uint32_t en1Size = request ? request->extranonce1_size() : 4;
+        const uint32_t en2Size = request ? request->extranonce2_size() : 4;
+        const uint64_t projectedScriptSigSize =
+            coinbaseTx.vin[0].scriptSig.size() + en1Size + en2Size;
+        if (projectedScriptSigSize > MAX_COINBASE_SCRIPTSIG_SIZE) {
+            return NngRpcErrorCode::INVALID_MINING_REQUEST;
+        }
+
+        pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
+        if (!pblocktemplate->entries.empty()) {
+            pblocktemplate->entries[0].tx = pblock->vtx[0];
+        }
+    }
+
     UpdateTime(pblock, chainparams, pindexPrev);
     pblock->nNonce = 0;
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
@@ -836,6 +861,11 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
 
     const uint32_t en1Size = request ? request->extranonce1_size() : 4;
     const uint32_t en2Size = request ? request->extranonce2_size() : 4;
+    const uint64_t projectedScriptSigSize =
+        pblock->vtx[0]->vin[0].scriptSig.size() + en1Size + en2Size;
+    if (projectedScriptSigSize > MAX_COINBASE_SCRIPTSIG_SIZE) {
+        return NngRpcErrorCode::INVALID_MINING_REQUEST;
+    }
     auto [cb1, cb2] = SplitCoinbase(*pblock->vtx[0], en1Size, en2Size);
 
     std::vector<flatbuffers::Offset<flatbuffers::String>> branchesFbs;

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -16,8 +16,10 @@
 #include <logging.h>
 #include <miner.h>
 #include <net.h>
+#include <policy/policy.h>
 #include <node/coin.h>
 #include <node/context.h>
+#include <node/transaction.h>
 #include <node/ui_interface.h>
 #include <streams.h>
 #include <timedata.h>
@@ -133,7 +135,7 @@ class NngRpcServer {
     nng_socket m_sock;
     std::vector<NngRpcWorker> m_workers;
     const Consensus::Params &m_consensus;
-    const NodeContext &m_node;
+    NodeContext &m_node;
 
     NngRpcErrorCode GetBlock(flatbuffers::FlatBufferBuilder &builder,
                              const NngInterface::GetBlockRequest *request);
@@ -169,8 +171,12 @@ class NngRpcServer {
     GetMiningStatus(flatbuffers::FlatBufferBuilder &builder,
                     const NngInterface::GetMiningStatusRequest *request);
 
+    NngRpcErrorCode SendRawTransaction(
+        flatbuffers::FlatBufferBuilder &builder,
+        const NngInterface::SendRawTransactionRequest *request);
+
 public:
-    NngRpcServer(const Consensus::Params &consensus, const NodeContext &node)
+    NngRpcServer(const Consensus::Params &consensus, NodeContext &node)
         : m_consensus(consensus), m_node(node) {}
 
     NngRpcErrorCode HandleMsg(flatbuffers::FlatBufferBuilder &builder,
@@ -303,6 +309,10 @@ NngRpcErrorCode NngRpcServer::HandleMsg(flatbuffers::FlatBufferBuilder &fbb,
         case NngInterface::RpcRequest_GetMiningStatusRequest: {
             return GetMiningStatus(fbb,
                                    rpc->rpc_as_GetMiningStatusRequest());
+        }
+        case NngInterface::RpcRequest_SendRawTransactionRequest: {
+            return SendRawTransaction(fbb,
+                                      rpc->rpc_as_SendRawTransactionRequest());
         }
         default:
             return NngRpcErrorCode::UNKNOWN_RPC_METHOD;
@@ -1043,6 +1053,71 @@ NngRpcErrorCode NngRpcServer::ValidateMinedBlockProposal(
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
 
+NngRpcErrorCode NngRpcServer::SendRawTransaction(
+    flatbuffers::FlatBufferBuilder &fbb,
+    const NngInterface::SendRawTransactionRequest *request) {
+    if (!request || !request->raw_tx()) {
+        return NngRpcErrorCode::INVALID_MINING_REQUEST;
+    }
+
+    CMutableTransaction mtx;
+    try {
+        std::vector<uint8_t> raw(request->raw_tx()->begin(), request->raw_tx()->end());
+        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
+        ss >> mtx;
+    } catch (...) {
+        TxId zeroTxid{};
+        auto resp = NngInterface::CreateSendRawTransactionResponse(
+            fbb, NngInterface::SendRawTransactionResult_DESERIALIZATION_ERROR,
+            false, CreateFbsTxId(fbb, zeroTxid),
+            fbb.CreateString("decode-failed"));
+        fbb.Finish(resp);
+        return NngRpcErrorCode::NO_RPC_ERROR;
+    }
+
+    CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
+    const uint64_t maxFeeRateSatPerKb = request->max_fee_rate();
+    Amount max_raw_tx_fee = DEFAULT_MAX_RAW_TX_FEE_RATE.GetFee(GetVirtualTransactionSize(*tx));
+    if (maxFeeRateSatPerKb > 0) {
+        const CFeeRate configured(int64_t(maxFeeRateSatPerKb) * Amount::satoshi());
+        max_raw_tx_fee = configured.GetFee(GetVirtualTransactionSize(*tx));
+    }
+
+    std::string err_string;
+    const Config &config = GetConfig();
+    TransactionError err = BroadcastTransaction(
+        m_node, config, tx, err_string, max_raw_tx_fee, request->relay(),
+        request->wait_callback());
+
+    NngInterface::SendRawTransactionResult result =
+        NngInterface::SendRawTransactionResult_MEMPOOL_ERROR;
+    switch (err) {
+        case TransactionError::OK:
+            result = NngInterface::SendRawTransactionResult_ACCEPTED;
+            break;
+        case TransactionError::ALREADY_IN_CHAIN:
+            result = NngInterface::SendRawTransactionResult_ALREADY_IN_CHAIN;
+            break;
+        case TransactionError::MAX_FEE_EXCEEDED:
+            result = NngInterface::SendRawTransactionResult_MAX_FEE_EXCEEDED;
+            break;
+        case TransactionError::MISSING_INPUTS:
+        case TransactionError::MEMPOOL_REJECTED:
+            result = NngInterface::SendRawTransactionResult_MEMPOOL_REJECTED;
+            break;
+        case TransactionError::MEMPOOL_ERROR:
+        default:
+            result = NngInterface::SendRawTransactionResult_MEMPOOL_ERROR;
+            break;
+    }
+
+    auto resp = NngInterface::CreateSendRawTransactionResponse(
+        fbb, result, err == TransactionError::OK, CreateFbsTxId(fbb, tx->GetId()),
+        fbb.CreateString(err_string));
+    fbb.Finish(resp);
+    return NngRpcErrorCode::NO_RPC_ERROR;
+}
+
 NngRpcErrorCode
 NngRpcServer::GetMiningStatus(flatbuffers::FlatBufferBuilder &fbb,
                               const NngInterface::GetMiningStatusRequest *request) {
@@ -1089,7 +1164,7 @@ public:
 private:
     nng_socket m_sock;
     std::set<std::string> m_enabled_messages;
-    // Monotonic process-local epoch used by miningworkchg.
+    // Monotonic process-local epoch used by miningwrkchg.
     std::atomic<uint64_t> m_templateEpoch{1};
 
     void BroadcastMessage(const std::string msg_type,
@@ -1103,7 +1178,7 @@ private:
 
     void EmitMiningWorkChanged(NngInterface::MiningWorkChangeReason reason,
                                const CBlockIndex *tip) {
-        if (!IsMessageEnabled(MSG_MININGWORKCHG) || tip == nullptr) {
+        if (!IsMessageEnabled(MSG_MININGWRKCHG) || tip == nullptr) {
             return;
         }
         // This signal is intentionally small and constant-shape to keep event
@@ -1113,7 +1188,7 @@ private:
         fbb.Finish(NngInterface::CreateMiningWorkChanged(
             fbb, reason, CreateFbsBlockHash(fbb, tip->GetBlockHash()),
             tip->nHeight, GetTime(), m_templateEpoch.fetch_add(1)));
-        BroadcastMessage(MSG_MININGWORKCHG, fbb);
+        BroadcastMessage(MSG_MININGWRKCHG, fbb);
     }
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew,
@@ -1146,7 +1221,7 @@ private:
             BroadcastMessage(MSG_MEMPOOLTXADD, fbb);
         }
 
-        if (IsMessageEnabled(MSG_MININGWORKCHG)) {
+        if (IsMessageEnabled(MSG_MININGWRKCHG)) {
             const CBlockIndex *tip = nullptr;
             {
                 LOCK(cs_main);
@@ -1167,7 +1242,7 @@ private:
             BroadcastMessage(MSG_MEMPOOLTXREM, fbb);
         }
 
-        if (IsMessageEnabled(MSG_MININGWORKCHG)) {
+        if (IsMessageEnabled(MSG_MININGWRKCHG)) {
             const CBlockIndex *tip = nullptr;
             {
                 LOCK(cs_main);
@@ -1221,7 +1296,7 @@ private:
 std::unique_ptr<NngRpcServer> g_rpc_server;
 std::unique_ptr<NngPubServer> g_pub_server;
 
-bool RunRpcServer(const NodeContext &node, const Consensus::Params &consensus) {
+bool RunRpcServer(NodeContext &node, const Consensus::Params &consensus) {
     if (gArgs.IsArgSet("-nngrpc")) {
         std::string rpc_url = gArgs.GetArg("-nngrpc", "");
         g_rpc_server = std::make_unique<NngRpcServer>(consensus, node);
@@ -1263,7 +1338,7 @@ bool RunPubServer() {
     return true;
 }
 
-bool StartNngInterface(const NodeContext &node,
+bool StartNngInterface(NodeContext &node,
                        const Consensus::Params &consensus) {
     if (!RunRpcServer(node, consensus)) {
         return false;

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -1083,6 +1083,8 @@ public:
 private:
     nng_socket m_sock;
     std::set<std::string> m_enabled_messages;
+    // Monotonic process-local epoch used by miningworkchg.
+    std::atomic<uint64_t> m_templateEpoch{1};
 
     void BroadcastMessage(const std::string msg_type,
                           const flatbuffers::FlatBufferBuilder &fbb) {
@@ -1093,43 +1095,77 @@ private:
         NNG_TRY_LOG(nng_send(m_sock, msg.data(), msg.size(), 0));
     }
 
+    void EmitMiningWorkChanged(NngInterface::MiningWorkChangeReason reason,
+                               const CBlockIndex *tip) {
+        if (!IsMessageEnabled(MSG_MININGWORKCHG) || tip == nullptr) {
+            return;
+        }
+        // This signal is intentionally small and constant-shape to keep event
+        // latency low for external stratum coordinators that refresh jobs on
+        // every tip/mempool invalidation.
+        flatbuffers::FlatBufferBuilder fbb;
+        fbb.Finish(NngInterface::CreateMiningWorkChanged(
+            fbb, reason, CreateFbsBlockHash(fbb, tip->GetBlockHash()),
+            tip->nHeight, GetTime(), m_templateEpoch.fetch_add(1)));
+        BroadcastMessage(MSG_MININGWORKCHG, fbb);
+    }
+
     void UpdatedBlockTip(const CBlockIndex *pindexNew,
                          const CBlockIndex *pindexFork,
                          bool fInitialDownload) override {
-        if (!IsMessageEnabled(MSG_UPDATEBLKTIP)) {
-            return;
+        if (IsMessageEnabled(MSG_UPDATEBLKTIP)) {
+            flatbuffers::FlatBufferBuilder fbb;
+            fbb.Finish(NngInterface::CreateUpdatedBlockTip(
+                fbb, CreateFbsBlockHash(fbb, pindexNew->GetBlockHash())));
+            BroadcastMessage(MSG_UPDATEBLKTIP, fbb);
         }
-        flatbuffers::FlatBufferBuilder fbb;
-        fbb.Finish(NngInterface::CreateUpdatedBlockTip(
-            fbb, CreateFbsBlockHash(fbb, pindexNew->GetBlockHash())));
-        BroadcastMessage(MSG_UPDATEBLKTIP, fbb);
+        EmitMiningWorkChanged(NngInterface::MiningWorkChangeReason_NEW_TIP,
+                              pindexNew);
     }
 
     void
     TransactionAddedToMempool(const CTransactionRef &ptx,
                               const std::vector<Coin> &spent_coins,
                               uint64_t mempool_sequence) override {
-        if (!IsMessageEnabled(MSG_MEMPOOLTXADD)) {
-            return;
+        if (IsMessageEnabled(MSG_MEMPOOLTXADD)) {
+            flatbuffers::FlatBufferBuilder fbb;
+            fbb.Finish(NngInterface::CreateTransactionAddedToMempool(
+                fbb, NngInterface::CreateMempoolTx(
+                         fbb, CreateFbsTxMempool(fbb, ptx, spent_coins),
+                         GetAdjustedTime())));
+            BroadcastMessage(MSG_MEMPOOLTXADD, fbb);
         }
-        flatbuffers::FlatBufferBuilder fbb;
-        fbb.Finish(NngInterface::CreateTransactionAddedToMempool(
-            fbb, NngInterface::CreateMempoolTx(
-                     fbb, CreateFbsTxMempool(fbb, ptx, spent_coins),
-                     GetAdjustedTime())));
-        BroadcastMessage(MSG_MEMPOOLTXADD, fbb);
+
+        if (IsMessageEnabled(MSG_MININGWORKCHG)) {
+            const CBlockIndex *tip = nullptr;
+            {
+                LOCK(cs_main);
+                tip = ::ChainActive().Tip();
+            }
+            EmitMiningWorkChanged(
+                NngInterface::MiningWorkChangeReason_MEMPOOL_UPDATE, tip);
+        }
     }
 
     void TransactionRemovedFromMempool(const CTransactionRef &ptx,
                                        MemPoolRemovalReason reason,
                                        uint64_t mempool_sequence) override {
-        if (!IsMessageEnabled(MSG_MEMPOOLTXREM)) {
-            return;
+        if (IsMessageEnabled(MSG_MEMPOOLTXREM)) {
+            flatbuffers::FlatBufferBuilder fbb;
+            fbb.Finish(NngInterface::CreateTransactionRemovedFromMempool(
+                fbb, CreateFbsTxId(fbb, ptx->GetId())));
+            BroadcastMessage(MSG_MEMPOOLTXREM, fbb);
         }
-        flatbuffers::FlatBufferBuilder fbb;
-        fbb.Finish(NngInterface::CreateTransactionRemovedFromMempool(
-            fbb, CreateFbsTxId(fbb, ptx->GetId())));
-        BroadcastMessage(MSG_MEMPOOLTXREM, fbb);
+
+        if (IsMessageEnabled(MSG_MININGWORKCHG)) {
+            const CBlockIndex *tip = nullptr;
+            {
+                LOCK(cs_main);
+                tip = ::ChainActive().Tip();
+            }
+            EmitMiningWorkChanged(
+                NngInterface::MiningWorkChangeReason_MEMPOOL_UPDATE, tip);
+        }
     }
 
     void BlockConnected(const std::shared_ptr<const CBlock> &block,

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -503,37 +503,54 @@ static std::string BytesToHex(const uint8_t *data, size_t len) {
 /**
  * Compute merkle branches for the coinbase (tx index 0), suitable for
  * Stratum-style coinbase-first merkle root reconstruction.
+ *
+ * Uses Lotus merkle leaf format: SHA256d(tx_hash || tx_id)
+ * Uses Lotus merkle tree construction: odd levels padded with uint256()
  */
 static std::vector<uint256> ComputeMerkleBranches(const CBlock &block) {
-    std::vector<uint256> branches;
+    // Compute leaves using Lotus leaf hash format
     std::vector<uint256> leaves;
+    leaves.reserve(block.vtx.size());
     for (const auto &tx : block.vtx) {
-        leaves.push_back(tx->GetHash());
-    }
-    if (leaves.size() <= 1) {
-        return branches;
+        CHashWriter leaf_hash(SER_GETHASH, 0);
+        leaf_hash << tx->GetHash();
+        leaf_hash << tx->GetId();
+        leaves.push_back(leaf_hash.GetHash());
     }
 
-    std::vector<uint256> level = leaves;
-    size_t index = 0;
-    while (level.size() > 1) {
-        size_t siblingIdx = index ^ 1;
-        if (siblingIdx < level.size()) {
-            branches.push_back(level[siblingIdx]);
+    if (leaves.empty()) {
+        return {};
+    }
+
+    // Compute merkle branch for position 0 (coinbase tx)
+    // This implements the same algorithm as MerkleComputation in merkle_tests.cpp
+    // but optimized for the coinbase-only case
+    std::vector<uint256> branch;
+    uint32_t index = 0;
+
+    while (leaves.size() > 1) {
+        // Determine sibling index and collect branch element
+        uint32_t siblingIdx = index ^ 1;
+        if (siblingIdx < leaves.size()) {
+            branch.push_back(leaves[siblingIdx]);
         } else {
-            branches.push_back(level[index]);
+            // Odd level: Lotus pads with uint256() (zero hash), not duplication
+            branch.push_back(uint256());
         }
 
+        // Build next level
         std::vector<uint256> nextLevel;
-        for (size_t i = 0; i < level.size(); i += 2) {
-            uint256 left = level[i];
-            uint256 right = (i + 1 < level.size()) ? level[i + 1] : left;
+        nextLevel.reserve((leaves.size() + 1) / 2);
+        for (size_t i = 0; i < leaves.size(); i += 2) {
+            uint256 left = leaves[i];
+            // Lotus: pad odd levels with uint256(), don't duplicate last element
+            uint256 right = (i + 1 < leaves.size()) ? leaves[i + 1] : uint256();
             nextLevel.push_back(Hash(left, right));
         }
-        level = std::move(nextLevel);
+        leaves = std::move(nextLevel);
         index /= 2;
     }
-    return branches;
+    return branch;
 }
 
 /**
@@ -763,12 +780,14 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
 
     CBlock *pblock = &pblocktemplate->block;
 
+    // Extract extranonce sizes early for consistent use throughout
+    const uint32_t en1Size = request ? request->extranonce1_size() : 4;
+    const uint32_t en2Size = request ? request->extranonce2_size() : 4;
+
     if (!coinbaseIdentity.empty()) {
         CMutableTransaction coinbaseTx(*pblock->vtx[0]);
         coinbaseTx.vin[0].scriptSig << coinbaseIdentity;
 
-        const uint32_t en1Size = request ? request->extranonce1_size() : 4;
-        const uint32_t en2Size = request ? request->extranonce2_size() : 4;
         const uint64_t projectedScriptSigSize =
             coinbaseTx.vin[0].scriptSig.size() + en1Size + en2Size;
         if (projectedScriptSigSize > MAX_COINBASE_SCRIPTSIG_SIZE) {
@@ -783,6 +802,48 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
 
     UpdateTime(pblock, chainparams, pindexPrev);
     pblock->nNonce = 0;
+
+    // Split coinbase BEFORE computing merkle root, using the original coinbase
+    // (without extranonce placeholder adjustment). SplitCoinbase will adjust
+    // the varint to account for extranonce space.
+    const uint64_t projectedScriptSigSize =
+        pblock->vtx[0]->vin[0].scriptSig.size() + en1Size + en2Size;
+    if (projectedScriptSigSize > MAX_COINBASE_SCRIPTSIG_SIZE) {
+        return NngRpcErrorCode::INVALID_MINING_REQUEST;
+    }
+    auto [cb1, cb2] = SplitCoinbase(*pblock->vtx[0], en1Size, en2Size);
+
+    // Construct a temporary coinbase that matches what stratum-server will
+    // reconstruct: coinbase1 || extranonce1 || extranonce2 || coinbase2.
+    // We use placeholder bytes (0x00) for extranonce since the actual values
+    // are miner-specific and don't affect the merkle root.
+    std::vector<uint256> merkleBranches;
+    {
+        // Parse coinbase1 to get the adjusted coinbase structure
+        std::vector<uint8_t> cb1Raw = ParseHex(cb1);
+        std::vector<uint8_t> cb2Raw = ParseHex(cb2);
+        
+        // Construct reconstructed coinbase: cb1 + placeholder_en1 + placeholder_en2 + cb2
+        std::vector<uint8_t> reconstructedRaw;
+        reconstructedRaw.reserve(cb1Raw.size() + en1Size + en2Size + cb2Raw.size());
+        reconstructedRaw.insert(reconstructedRaw.end(), cb1Raw.begin(), cb1Raw.end());
+        reconstructedRaw.insert(reconstructedRaw.end(), en1Size + en2Size, 0x00); // placeholder extranonce
+        reconstructedRaw.insert(reconstructedRaw.end(), cb2Raw.begin(), cb2Raw.end());
+        
+        // Deserialize reconstructed coinbase
+        CDataStream reconstructedSs(reconstructedRaw, SER_NETWORK, PROTOCOL_VERSION);
+        CTransaction reconstructedCoinbase(deserialize, reconstructedSs);
+        
+        // Create a temporary block with the reconstructed coinbase for merkle computation
+        CBlock tempBlock = *pblock;
+        tempBlock.vtx[0] = MakeTransactionRef(reconstructedCoinbase);
+        
+        // Compute merkle root and branches from reconstructed coinbase
+        tempBlock.hashMerkleRoot = BlockMerkleRoot(tempBlock);
+        merkleBranches = ComputeMerkleBranches(tempBlock);
+    }
+    
+    // Set the merkle root on the original block (for serialization)
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 
     CDataStream blockStream(SER_NETWORK, PROTOCOL_VERSION);
@@ -797,17 +858,8 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
         coinbaseValue += out.nValue;
     }
 
-    const uint32_t en1Size = request ? request->extranonce1_size() : 4;
-    const uint32_t en2Size = request ? request->extranonce2_size() : 4;
-    const uint64_t projectedScriptSigSize =
-        pblock->vtx[0]->vin[0].scriptSig.size() + en1Size + en2Size;
-    if (projectedScriptSigSize > MAX_COINBASE_SCRIPTSIG_SIZE) {
-        return NngRpcErrorCode::INVALID_MINING_REQUEST;
-    }
-    auto [cb1, cb2] = SplitCoinbase(*pblock->vtx[0], en1Size, en2Size);
-
     std::vector<flatbuffers::Offset<flatbuffers::String>> branchesFbs;
-    for (const auto &branch : ComputeMerkleBranches(*pblock)) {
+    for (const auto &branch : merkleBranches) {
         branchesFbs.push_back(fbb.CreateString(branch.GetHex()));
     }
 

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -3,17 +3,27 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <array>
+#include <atomic>
 #include <optional>
 
 #include <blockdb.h>
 #include <chainparams.h>
+#include <config.h>
 #include <consensus/validation.h>
+#include <consensus/merkle.h>
+#include <hash.h>
 #include <logging.h>
+#include <miner.h>
+#include <net.h>
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/ui_interface.h>
+#include <streams.h>
 #include <timedata.h>
 #include <undo.h>
+#include <univalue.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -61,8 +71,10 @@ enum class NngRpcErrorCode {
     BLOCK_NOT_FOUND,
     BLOCK_DATA_CORRUPTED,
     INVALID_BLOCK_SLICE,
+    INVALID_MINING_REQUEST,
+    MINING_TEMPLATE_BUILD_FAILED,
+    MINING_SUBMIT_DECODE_FAILED,
 };
-
 struct RpcResult {
     NngRpcErrorCode error_code;
     std::vector<uint8_t> data = std::vector<uint8_t>();
@@ -85,6 +97,12 @@ std::string ErrorMsg(NngRpcErrorCode code) {
             return "Block data corrupted";
         case NngRpcErrorCode::INVALID_BLOCK_SLICE:
             return "Invalid block slice";
+        case NngRpcErrorCode::INVALID_MINING_REQUEST:
+            return "Invalid mining request";
+        case NngRpcErrorCode::MINING_TEMPLATE_BUILD_FAILED:
+            return "Failed to build mining template";
+        case NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED:
+            return "Failed to decode mined block";
         default:
             return "Unknown error";
     }
@@ -133,6 +151,22 @@ class NngRpcServer {
 
     NngRpcErrorCode GetMempool(flatbuffers::FlatBufferBuilder &builder,
                                const NngInterface::GetMempoolRequest *request);
+
+    NngRpcErrorCode
+    GetMiningTemplate(flatbuffers::FlatBufferBuilder &builder,
+                      const NngInterface::GetMiningTemplateRequest *request);
+
+    NngRpcErrorCode
+    SubmitMinedBlock(flatbuffers::FlatBufferBuilder &builder,
+                     const NngInterface::SubmitMinedBlockRequest *request);
+
+    NngRpcErrorCode ValidateMinedBlockProposal(
+        flatbuffers::FlatBufferBuilder &builder,
+        const NngInterface::ValidateMinedBlockProposalRequest *request);
+
+    NngRpcErrorCode
+    GetMiningStatus(flatbuffers::FlatBufferBuilder &builder,
+                    const NngInterface::GetMiningStatusRequest *request);
 
 public:
     NngRpcServer(const Consensus::Params &consensus, const NodeContext &node)
@@ -252,6 +286,22 @@ NngRpcErrorCode NngRpcServer::HandleMsg(flatbuffers::FlatBufferBuilder &fbb,
         }
         case NngInterface::RpcRequest_GetMempoolRequest: {
             return GetMempool(fbb, rpc->rpc_as_GetMempoolRequest());
+        }
+        case NngInterface::RpcRequest_GetMiningTemplateRequest: {
+            return GetMiningTemplate(fbb,
+                                     rpc->rpc_as_GetMiningTemplateRequest());
+        }
+        case NngInterface::RpcRequest_SubmitMinedBlockRequest: {
+            return SubmitMinedBlock(fbb,
+                                    rpc->rpc_as_SubmitMinedBlockRequest());
+        }
+        case NngInterface::RpcRequest_ValidateMinedBlockProposalRequest: {
+            return ValidateMinedBlockProposal(
+                fbb, rpc->rpc_as_ValidateMinedBlockProposalRequest());
+        }
+        case NngInterface::RpcRequest_GetMiningStatusRequest: {
+            return GetMiningStatus(fbb,
+                                   rpc->rpc_as_GetMiningStatusRequest());
         }
         default:
             return NngRpcErrorCode::UNKNOWN_RPC_METHOD;
@@ -433,6 +483,187 @@ CreateFbsBlock(flatbuffers::FlatBufferBuilder &fbb, const CBlock &block,
         pindex->nDataPos, pindex->nUndoPos);
 }
 
+/**
+ * Convert a uint256 hash to canonical stratum hex encoding used by mining
+ * clients: each 32-bit word is byte-reversed while preserving word order.
+ */
+static std::string HashToStratumHex(const uint256 &hash) {
+    const uint8_t *data = hash.begin();
+    std::string result;
+    result.reserve(64);
+    for (int i = 0; i < 32; i += 4) {
+        for (int j = 3; j >= 0; j--) {
+            result += strprintf("%02x", data[i + j]);
+        }
+    }
+    return result;
+}
+
+/** Convert a 32-bit integer to little-endian hex as used by Stratum params. */
+static std::string Uint32ToStratumHex(uint32_t val) {
+    uint8_t buf[4];
+    buf[0] = val & 0xff;
+    buf[1] = (val >> 8) & 0xff;
+    buf[2] = (val >> 16) & 0xff;
+    buf[3] = (val >> 24) & 0xff;
+    return HexStr(Span<const uint8_t>(buf, 4));
+}
+
+/** Convert raw bytes to lowercase hex preserving byte order. */
+static std::string BytesToHex(const uint8_t *data, size_t len) {
+    return HexStr(Span<const uint8_t>(data, len));
+}
+
+/**
+ * Compute merkle branches for the coinbase (tx index 0), suitable for
+ * Stratum-style coinbase-first merkle root reconstruction.
+ */
+static std::vector<uint256> ComputeMerkleBranches(const CBlock &block) {
+    std::vector<uint256> branches;
+    std::vector<uint256> leaves;
+    for (const auto &tx : block.vtx) {
+        leaves.push_back(tx->GetHash());
+    }
+    if (leaves.size() <= 1) {
+        return branches;
+    }
+
+    std::vector<uint256> level = leaves;
+    size_t index = 0;
+    while (level.size() > 1) {
+        size_t siblingIdx = index ^ 1;
+        if (siblingIdx < level.size()) {
+            branches.push_back(level[siblingIdx]);
+        } else {
+            branches.push_back(level[index]);
+        }
+
+        std::vector<uint256> nextLevel;
+        for (size_t i = 0; i < level.size(); i += 2) {
+            uint256 left = level[i];
+            uint256 right = (i + 1 < level.size()) ? level[i + 1] : left;
+            nextLevel.push_back(Hash(left, right));
+        }
+        level = std::move(nextLevel);
+        index /= 2;
+    }
+    return branches;
+}
+
+/**
+ * Split coinbase into coinbase1/coinbase2 for stratum extranonce insertion.
+ *
+ * The output is deterministic and updates scriptSig compact-size encoding to
+ * account for reserved extranonce bytes.
+ */
+static std::pair<std::string, std::string>
+SplitCoinbase(const CTransaction &coinbaseTx, size_t extranonce1Size,
+              size_t extranonce2Size) {
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << coinbaseTx;
+    std::vector<uint8_t> raw((const uint8_t *)ss.data(),
+                             (const uint8_t *)ss.data() + ss.size());
+
+    size_t pos = 0;
+    pos += 4;  // version
+    pos += 1;  // vin count (coinbase always one input)
+    pos += 36; // prevout
+
+    size_t scriptSigLenPos = pos;
+
+    uint64_t origScriptSigLen = 0;
+    int varintBytes = 0;
+    if (raw[pos] < 0xfd) {
+        origScriptSigLen = raw[pos];
+        varintBytes = 1;
+    } else if (raw[pos] == 0xfd) {
+        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8);
+        varintBytes = 3;
+    } else {
+        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8) |
+                           (raw[pos + 3] << 16) |
+                           ((uint64_t)raw[pos + 4] << 24);
+        varintBytes = 5;
+    }
+    pos += varintBytes;
+
+    size_t scriptSigStart = pos;
+    size_t scriptSigEnd = pos + origScriptSigLen;
+
+    uint64_t extranonceSpace = extranonce1Size + extranonce2Size;
+    uint64_t newScriptSigLen = origScriptSigLen + extranonceSpace;
+
+    std::vector<uint8_t> newVarint;
+    if (newScriptSigLen < 0xfd) {
+        newVarint.push_back((uint8_t)newScriptSigLen);
+    } else if (newScriptSigLen <= 0xffff) {
+        newVarint.push_back(0xfd);
+        newVarint.push_back(newScriptSigLen & 0xff);
+        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
+    } else {
+        newVarint.push_back(0xfe);
+        newVarint.push_back(newScriptSigLen & 0xff);
+        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
+        newVarint.push_back((newScriptSigLen >> 16) & 0xff);
+        newVarint.push_back((newScriptSigLen >> 24) & 0xff);
+    }
+
+    std::vector<uint8_t> cb1Data;
+    cb1Data.insert(cb1Data.end(), raw.begin(), raw.begin() + scriptSigLenPos);
+    cb1Data.insert(cb1Data.end(), newVarint.begin(), newVarint.end());
+    cb1Data.insert(cb1Data.end(), raw.begin() + scriptSigStart,
+                   raw.begin() + scriptSigEnd);
+
+    std::vector<uint8_t> cb2Data(raw.begin() + scriptSigEnd, raw.end());
+    return {HexStr(cb1Data), HexStr(cb2Data)};
+}
+
+/**
+ * BIP22-inspired mapping used by mining submit/proposal responses.
+ *
+ * `reason == std::nullopt` means acceptance (JSON null in BIP22 terms).
+ */
+static NngInterface::MiningSubmitResult MapMiningSubmitReason(
+    const std::optional<std::string> &reasonOpt) {
+    if (!reasonOpt.has_value()) {
+        return NngInterface::MiningSubmitResult_ACCEPTED;
+    }
+    const std::string &reason = *reasonOpt;
+    if (reason == "duplicate") {
+        return NngInterface::MiningSubmitResult_DUPLICATE;
+    }
+    if (reason == "duplicate-invalid") {
+        return NngInterface::MiningSubmitResult_DUPLICATE_INVALID;
+    }
+    if (reason == "duplicate-inconclusive") {
+        return NngInterface::MiningSubmitResult_DUPLICATE_INCONCLUSIVE;
+    }
+    if (reason == "inconclusive" || reason == "inconclusive-not-best-prevblk") {
+        return NngInterface::MiningSubmitResult_INCONCLUSIVE;
+    }
+    return NngInterface::MiningSubmitResult_REJECTED;
+}
+
+class NngSubmitBlockStateCatcher final : public CValidationInterface {
+public:
+    uint256 hash;
+    bool found;
+    BlockValidationState state;
+
+    explicit NngSubmitBlockStateCatcher(const uint256 &hashIn)
+        : hash(hashIn), found(false), state() {}
+
+protected:
+    void BlockChecked(const CBlock &block,
+                      const BlockValidationState &stateIn) override {
+        if (block.GetHash() != hash) {
+            return;
+        }
+        found = true;
+        state = stateIn;
+    }
+};
+
 NngRpcErrorCode
 NngRpcServer::GetBlock(flatbuffers::FlatBufferBuilder &fbb,
                        const NngInterface::GetBlockRequest *request) {
@@ -541,6 +772,292 @@ NngRpcServer::GetMempool(flatbuffers::FlatBufferBuilder &fbb,
     }
     fbb.Finish(
         NngInterface::CreateGetMempoolResponse(fbb, fbb.CreateVector(txs_fbs)));
+    return NngRpcErrorCode::NO_RPC_ERROR;
+}
+
+NngRpcErrorCode NngRpcServer::GetMiningTemplate(
+    flatbuffers::FlatBufferBuilder &fbb,
+    const NngInterface::GetMiningTemplateRequest *request) {
+    const Config &config = GetConfig();
+    const CChainParams &chainparams = config.GetChainParams();
+
+    LOCK(cs_main);
+    CBlockIndex *pindexPrev = ::ChainActive().Tip();
+    if (!pindexPrev) {
+        return NngRpcErrorCode::MINING_TEMPLATE_BUILD_FAILED;
+    }
+
+    CScript coinbaseScript;
+    if (request && request->coinbase_script()) {
+        const auto &scriptBytes = *request->coinbase_script();
+        if (scriptBytes.size() > 0) {
+            std::vector<uint8_t> scriptVec(scriptBytes.begin(),
+                                           scriptBytes.end());
+            coinbaseScript = CScript(scriptVec.begin(), scriptVec.end());
+        }
+    }
+    if (coinbaseScript.empty()) {
+        // Keep behavior predictable for pure-template callers: this mirrors
+        // getblocktemplate's scriptDummy behavior and avoids address parsing
+        // policy decisions in the NNG layer.
+        coinbaseScript = CScript() << OP_RETURN;
+    }
+
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    try {
+        pblocktemplate = BlockAssembler(config, *m_node.mempool)
+                             .CreateNewBlock(coinbaseScript);
+    } catch (const std::exception &e) {
+        LogPrintf("NNG mining template build failed: %s\n", e.what());
+        return NngRpcErrorCode::MINING_TEMPLATE_BUILD_FAILED;
+    }
+    if (!pblocktemplate) {
+        return NngRpcErrorCode::MINING_TEMPLATE_BUILD_FAILED;
+    }
+
+    CBlock *pblock = &pblocktemplate->block;
+    UpdateTime(pblock, chainparams, pindexPrev);
+    pblock->nNonce = 0;
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+
+    CDataStream blockStream(SER_NETWORK, PROTOCOL_VERSION);
+    blockStream << *pblock;
+    CDataStream headerStream(SER_NETWORK, PROTOCOL_VERSION);
+    headerStream << pblock->GetBlockHeader();
+    CDataStream coinbaseStream(SER_NETWORK, PROTOCOL_VERSION);
+    coinbaseStream << *pblock->vtx[0];
+
+    Amount coinbaseValue = Amount::zero();
+    for (const auto &out : pblock->vtx[0]->vout) {
+        coinbaseValue += out.nValue;
+    }
+
+    const uint32_t en1Size = request ? request->extranonce1_size() : 4;
+    const uint32_t en2Size = request ? request->extranonce2_size() : 4;
+    auto [cb1, cb2] = SplitCoinbase(*pblock->vtx[0], en1Size, en2Size);
+
+    std::vector<flatbuffers::Offset<flatbuffers::String>> branchesFbs;
+    for (const auto &branch : ComputeMerkleBranches(*pblock)) {
+        branchesFbs.push_back(fbb.CreateString(branch.GetHex()));
+    }
+
+    std::vector<flatbuffers::Offset<NngInterface::MiningTemplateTx>> txsFbs;
+    const bool includeTxs = request ? request->include_transactions() : true;
+    if (includeTxs) {
+        for (size_t i = 1; i < pblock->vtx.size(); ++i) {
+            CDataStream txStream(SER_NETWORK, PROTOCOL_VERSION);
+            txStream << *pblock->vtx[i];
+            Amount fee = Amount::zero();
+            int64_t sigops = 0;
+            if (i < pblocktemplate->entries.size()) {
+                fee = pblocktemplate->entries[i].fees;
+                sigops = pblocktemplate->entries[i].sigOpCount;
+            }
+            txsFbs.push_back(NngInterface::CreateMiningTemplateTx(
+                fbb,
+                fbb.CreateVector((const uint8_t *)txStream.data(),
+                                 txStream.size()),
+                CreateFbsTxId(fbb, pblock->vtx[i]->GetId()),
+                fee / SATOSHI, sigops));
+        }
+    }
+
+    static std::atomic<uint64_t> s_templateId{1};
+    const uint64_t templateId = s_templateId.fetch_add(1);
+
+    arith_uint256 targetArith;
+    targetArith.SetCompact(pblock->nBits);
+    const uint256 targetU256 = ArithToUint256(targetArith);
+    NngInterface::Hash targetHash = CreateFbsHash(targetU256.begin());
+
+    const uint64_t mintime = pindexPrev->GetMedianTimePast() + 1;
+
+    auto response = NngInterface::CreateGetMiningTemplateResponse(
+        fbb, templateId,
+        fbb.CreateVector((const uint8_t *)blockStream.data(), blockStream.size()),
+        fbb.CreateVector((const uint8_t *)headerStream.data(),
+                         headerStream.size()),
+        CreateFbsBlockHash(fbb, pblock->hashPrevBlock), pindexPrev->nHeight + 1,
+        pblock->nBits, &targetHash, pblock->GetBlockTime(),
+        mintime, coinbaseValue / SATOSHI,
+        fbb.CreateVector((const uint8_t *)coinbaseStream.data(),
+                         coinbaseStream.size()),
+        fbb.CreateVector(txsFbs), fbb.CreateString(cb1), fbb.CreateString(cb2),
+        fbb.CreateVector(branchesFbs),
+        fbb.CreateString(HashToStratumHex(pblock->hashPrevBlock)),
+        fbb.CreateString(Uint32ToStratumHex(pblock->nBits)),
+        fbb.CreateString(BytesToHex(pblock->vTime.data(), pblock->vTime.size())));
+    fbb.Finish(response);
+    return NngRpcErrorCode::NO_RPC_ERROR;
+}
+
+NngRpcErrorCode NngRpcServer::SubmitMinedBlock(
+    flatbuffers::FlatBufferBuilder &fbb,
+    const NngInterface::SubmitMinedBlockRequest *request) {
+    if (!request || !request->block()) {
+        return NngRpcErrorCode::INVALID_MINING_REQUEST;
+    }
+
+    CBlock block;
+    try {
+        std::vector<uint8_t> raw(request->block()->begin(), request->block()->end());
+        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
+        ss >> block;
+    } catch (...) {
+        return NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED;
+    }
+
+    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+        auto resp = NngInterface::CreateSubmitMinedBlockResponse(
+            fbb, NngInterface::MiningSubmitResult_INVALID_COINBASE, false,
+            fbb.CreateString("Block does not start with a coinbase"));
+        fbb.Finish(resp);
+        return NngRpcErrorCode::NO_RPC_ERROR;
+    }
+
+    const Config &config = GetConfig();
+    const uint256 hash = block.GetHash();
+    {
+        LOCK(cs_main);
+        const CBlockIndex *pindex = LookupBlockIndex(BlockHash(hash));
+        if (pindex) {
+            NngInterface::MiningSubmitResult code =
+                pindex->IsValid(BlockValidity::SCRIPTS)
+                    ? NngInterface::MiningSubmitResult_DUPLICATE
+                    : (pindex->nStatus.isInvalid()
+                           ? NngInterface::MiningSubmitResult_DUPLICATE_INVALID
+                           : NngInterface::MiningSubmitResult_DUPLICATE_INCONCLUSIVE);
+            std::string reason =
+                code == NngInterface::MiningSubmitResult_DUPLICATE
+                    ? "duplicate"
+                    : (code == NngInterface::MiningSubmitResult_DUPLICATE_INVALID
+                           ? "duplicate-invalid"
+                           : "duplicate-inconclusive");
+            auto resp = NngInterface::CreateSubmitMinedBlockResponse(
+                fbb, code, false, fbb.CreateString(reason));
+            fbb.Finish(resp);
+            return NngRpcErrorCode::NO_RPC_ERROR;
+        }
+    }
+
+    bool new_block = false;
+    auto blockptr = std::make_shared<CBlock>(std::move(block));
+    auto sc = std::make_shared<NngSubmitBlockStateCatcher>(hash);
+    RegisterSharedValidationInterface(sc);
+    bool accepted = m_node.chainman->ProcessNewBlock(config, blockptr,
+                                                      /* fForceProcessing */ true,
+                                                      &new_block);
+    UnregisterSharedValidationInterface(sc);
+
+    std::optional<std::string> bip22Reason = std::string("inconclusive");
+    if (!new_block && accepted) {
+        bip22Reason = std::string("duplicate");
+    } else if (sc->found) {
+        if (sc->state.IsValid()) {
+            bip22Reason = std::nullopt;
+        } else if (sc->state.IsInvalid()) {
+            std::string reject = sc->state.GetRejectReason();
+            bip22Reason = reject.empty() ? std::optional<std::string>("rejected")
+                                         : std::optional<std::string>(reject);
+        } else {
+            bip22Reason = std::string("inconclusive");
+        }
+    }
+
+    const auto result = MapMiningSubmitReason(bip22Reason);
+    const bool blockAccepted =
+        result == NngInterface::MiningSubmitResult_ACCEPTED;
+    const std::string reason = bip22Reason.has_value() ? *bip22Reason : "";
+    auto resp = NngInterface::CreateSubmitMinedBlockResponse(
+        fbb, result, blockAccepted, fbb.CreateString(reason));
+    fbb.Finish(resp);
+    return NngRpcErrorCode::NO_RPC_ERROR;
+}
+
+NngRpcErrorCode NngRpcServer::ValidateMinedBlockProposal(
+    flatbuffers::FlatBufferBuilder &fbb,
+    const NngInterface::ValidateMinedBlockProposalRequest *request) {
+    if (!request || !request->block()) {
+        return NngRpcErrorCode::INVALID_MINING_REQUEST;
+    }
+
+    CBlock block;
+    try {
+        std::vector<uint8_t> raw(request->block()->begin(), request->block()->end());
+        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
+        ss >> block;
+    } catch (...) {
+        return NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED;
+    }
+
+    const Config &config = GetConfig();
+    const CChainParams &chainparams = config.GetChainParams();
+
+    std::optional<std::string> bip22Reason = std::nullopt;
+    {
+        LOCK(cs_main);
+        const uint256 hash = block.GetHash();
+        const CBlockIndex *pindex = LookupBlockIndex(BlockHash(hash));
+        if (pindex) {
+            if (pindex->IsValid(BlockValidity::SCRIPTS)) {
+                bip22Reason = std::string("duplicate");
+            } else if (pindex->nStatus.isInvalid()) {
+                bip22Reason = std::string("duplicate-invalid");
+            } else {
+                bip22Reason = std::string("duplicate-inconclusive");
+            }
+        } else {
+            CBlockIndex *const pindexPrev = ::ChainActive().Tip();
+            if (!pindexPrev || block.hashPrevBlock != pindexPrev->GetBlockHash()) {
+                bip22Reason = std::string("inconclusive-not-best-prevblk");
+            } else {
+                BlockValidationState state;
+                TestBlockValidity(state, chainparams, block, pindexPrev,
+                                  BlockValidationOptions(config)
+                                      .withCheckPoW(false)
+                                      .withCheckMerkleRoot(true));
+                if (state.IsValid()) {
+                    bip22Reason = std::nullopt;
+                } else if (state.IsInvalid()) {
+                    std::string reject = state.GetRejectReason();
+                    bip22Reason = reject.empty()
+                                      ? std::optional<std::string>("rejected")
+                                      : std::optional<std::string>(reject);
+                } else {
+                    bip22Reason = std::string("inconclusive");
+                }
+            }
+        }
+    }
+
+    const auto result = MapMiningSubmitReason(bip22Reason);
+    auto resp = NngInterface::CreateValidateMinedBlockProposalResponse(
+        fbb, result, result == NngInterface::MiningSubmitResult_ACCEPTED,
+        fbb.CreateString(bip22Reason.has_value() ? *bip22Reason : ""));
+    fbb.Finish(resp);
+    return NngRpcErrorCode::NO_RPC_ERROR;
+}
+
+NngRpcErrorCode
+NngRpcServer::GetMiningStatus(flatbuffers::FlatBufferBuilder &fbb,
+                              const NngInterface::GetMiningStatusRequest *request) {
+    LOCK(cs_main);
+    const CBlockIndex *tip = ::ChainActive().Tip();
+    if (!tip) {
+        return NngRpcErrorCode::BLOCK_NOT_FOUND;
+    }
+
+    uint32_t peers = 0;
+    if (m_node.connman) {
+        peers = m_node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
+    }
+
+    auto resp = NngInterface::CreateGetMiningStatusResponse(
+        fbb, CreateFbsBlockHash(fbb, tip->GetBlockHash()), tip->nHeight,
+        ::ChainstateActive().IsInitialBlockDownload(),
+        static_cast<uint64_t>(m_node.mempool->size()), peers,
+        fbb.CreateString(GetConfig().GetChainParams().NetworkIDString()));
+    fbb.Finish(resp);
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
 

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -16,10 +16,8 @@
 #include <logging.h>
 #include <miner.h>
 #include <net.h>
-#include <policy/policy.h>
 #include <node/coin.h>
 #include <node/context.h>
-#include <node/transaction.h>
 #include <node/ui_interface.h>
 #include <streams.h>
 #include <timedata.h>
@@ -135,7 +133,7 @@ class NngRpcServer {
     nng_socket m_sock;
     std::vector<NngRpcWorker> m_workers;
     const Consensus::Params &m_consensus;
-    NodeContext &m_node;
+    const NodeContext &m_node;
 
     NngRpcErrorCode GetBlock(flatbuffers::FlatBufferBuilder &builder,
                              const NngInterface::GetBlockRequest *request);
@@ -171,12 +169,9 @@ class NngRpcServer {
     GetMiningStatus(flatbuffers::FlatBufferBuilder &builder,
                     const NngInterface::GetMiningStatusRequest *request);
 
-    NngRpcErrorCode SendRawTransaction(
-        flatbuffers::FlatBufferBuilder &builder,
-        const NngInterface::SendRawTransactionRequest *request);
 
 public:
-    NngRpcServer(const Consensus::Params &consensus, NodeContext &node)
+    NngRpcServer(const Consensus::Params &consensus, const NodeContext &node)
         : m_consensus(consensus), m_node(node) {}
 
     NngRpcErrorCode HandleMsg(flatbuffers::FlatBufferBuilder &builder,
@@ -309,10 +304,6 @@ NngRpcErrorCode NngRpcServer::HandleMsg(flatbuffers::FlatBufferBuilder &fbb,
         case NngInterface::RpcRequest_GetMiningStatusRequest: {
             return GetMiningStatus(fbb,
                                    rpc->rpc_as_GetMiningStatusRequest());
-        }
-        case NngInterface::RpcRequest_SendRawTransactionRequest: {
-            return SendRawTransaction(fbb,
-                                      rpc->rpc_as_SendRawTransactionRequest());
         }
         default:
             return NngRpcErrorCode::UNKNOWN_RPC_METHOD;
@@ -1053,71 +1044,6 @@ NngRpcErrorCode NngRpcServer::ValidateMinedBlockProposal(
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
 
-NngRpcErrorCode NngRpcServer::SendRawTransaction(
-    flatbuffers::FlatBufferBuilder &fbb,
-    const NngInterface::SendRawTransactionRequest *request) {
-    if (!request || !request->raw_tx()) {
-        return NngRpcErrorCode::INVALID_MINING_REQUEST;
-    }
-
-    CMutableTransaction mtx;
-    try {
-        std::vector<uint8_t> raw(request->raw_tx()->begin(), request->raw_tx()->end());
-        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
-        ss >> mtx;
-    } catch (...) {
-        TxId zeroTxid{};
-        auto resp = NngInterface::CreateSendRawTransactionResponse(
-            fbb, NngInterface::SendRawTransactionResult_DESERIALIZATION_ERROR,
-            false, CreateFbsTxId(fbb, zeroTxid),
-            fbb.CreateString("decode-failed"));
-        fbb.Finish(resp);
-        return NngRpcErrorCode::NO_RPC_ERROR;
-    }
-
-    CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
-    const uint64_t maxFeeRateSatPerKb = request->max_fee_rate();
-    Amount max_raw_tx_fee = DEFAULT_MAX_RAW_TX_FEE_RATE.GetFee(GetVirtualTransactionSize(*tx));
-    if (maxFeeRateSatPerKb > 0) {
-        const CFeeRate configured(int64_t(maxFeeRateSatPerKb) * Amount::satoshi());
-        max_raw_tx_fee = configured.GetFee(GetVirtualTransactionSize(*tx));
-    }
-
-    std::string err_string;
-    const Config &config = GetConfig();
-    TransactionError err = BroadcastTransaction(
-        m_node, config, tx, err_string, max_raw_tx_fee, request->relay(),
-        request->wait_callback());
-
-    NngInterface::SendRawTransactionResult result =
-        NngInterface::SendRawTransactionResult_MEMPOOL_ERROR;
-    switch (err) {
-        case TransactionError::OK:
-            result = NngInterface::SendRawTransactionResult_ACCEPTED;
-            break;
-        case TransactionError::ALREADY_IN_CHAIN:
-            result = NngInterface::SendRawTransactionResult_ALREADY_IN_CHAIN;
-            break;
-        case TransactionError::MAX_FEE_EXCEEDED:
-            result = NngInterface::SendRawTransactionResult_MAX_FEE_EXCEEDED;
-            break;
-        case TransactionError::MISSING_INPUTS:
-        case TransactionError::MEMPOOL_REJECTED:
-            result = NngInterface::SendRawTransactionResult_MEMPOOL_REJECTED;
-            break;
-        case TransactionError::MEMPOOL_ERROR:
-        default:
-            result = NngInterface::SendRawTransactionResult_MEMPOOL_ERROR;
-            break;
-    }
-
-    auto resp = NngInterface::CreateSendRawTransactionResponse(
-        fbb, result, err == TransactionError::OK, CreateFbsTxId(fbb, tx->GetId()),
-        fbb.CreateString(err_string));
-    fbb.Finish(resp);
-    return NngRpcErrorCode::NO_RPC_ERROR;
-}
-
 NngRpcErrorCode
 NngRpcServer::GetMiningStatus(flatbuffers::FlatBufferBuilder &fbb,
                               const NngInterface::GetMiningStatusRequest *request) {
@@ -1296,7 +1222,7 @@ private:
 std::unique_ptr<NngRpcServer> g_rpc_server;
 std::unique_ptr<NngPubServer> g_pub_server;
 
-bool RunRpcServer(NodeContext &node, const Consensus::Params &consensus) {
+bool RunRpcServer(const NodeContext &node, const Consensus::Params &consensus) {
     if (gArgs.IsArgSet("-nngrpc")) {
         std::string rpc_url = gArgs.GetArg("-nngrpc", "");
         g_rpc_server = std::make_unique<NngRpcServer>(consensus, node);
@@ -1338,7 +1264,7 @@ bool RunPubServer() {
     return true;
 }
 
-bool StartNngInterface(NodeContext &node,
+bool StartNngInterface(const NodeContext &node,
                        const Consensus::Params &consensus) {
     if (!RunRpcServer(node, consensus)) {
         return false;

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -158,14 +158,6 @@ class NngRpcServer {
                       const NngInterface::GetMiningTemplateRequest *request);
 
     NngRpcErrorCode
-    SubmitMinedBlock(flatbuffers::FlatBufferBuilder &builder,
-                     const NngInterface::SubmitMinedBlockRequest *request);
-
-    NngRpcErrorCode ValidateMinedBlockProposal(
-        flatbuffers::FlatBufferBuilder &builder,
-        const NngInterface::ValidateMinedBlockProposalRequest *request);
-
-    NngRpcErrorCode
     GetMiningStatus(flatbuffers::FlatBufferBuilder &builder,
                     const NngInterface::GetMiningStatusRequest *request);
 
@@ -292,14 +284,6 @@ NngRpcErrorCode NngRpcServer::HandleMsg(flatbuffers::FlatBufferBuilder &fbb,
         case NngInterface::RpcRequest_GetMiningTemplateRequest: {
             return GetMiningTemplate(fbb,
                                      rpc->rpc_as_GetMiningTemplateRequest());
-        }
-        case NngInterface::RpcRequest_SubmitMinedBlockRequest: {
-            return SubmitMinedBlock(fbb,
-                                    rpc->rpc_as_SubmitMinedBlockRequest());
-        }
-        case NngInterface::RpcRequest_ValidateMinedBlockProposalRequest: {
-            return ValidateMinedBlockProposal(
-                fbb, rpc->rpc_as_ValidateMinedBlockProposalRequest());
         }
         case NngInterface::RpcRequest_GetMiningStatusRequest: {
             return GetMiningStatus(fbb,
@@ -620,52 +604,6 @@ SplitCoinbase(const CTransaction &coinbaseTx, size_t extranonce1Size,
     return {HexStr(cb1Data), HexStr(cb2Data)};
 }
 
-/**
- * BIP22-inspired mapping used by mining submit/proposal responses.
- *
- * `reason == std::nullopt` means acceptance (JSON null in BIP22 terms).
- */
-static NngInterface::MiningSubmitResult MapMiningSubmitReason(
-    const std::optional<std::string> &reasonOpt) {
-    if (!reasonOpt.has_value()) {
-        return NngInterface::MiningSubmitResult_ACCEPTED;
-    }
-    const std::string &reason = *reasonOpt;
-    if (reason == "duplicate") {
-        return NngInterface::MiningSubmitResult_DUPLICATE;
-    }
-    if (reason == "duplicate-invalid") {
-        return NngInterface::MiningSubmitResult_DUPLICATE_INVALID;
-    }
-    if (reason == "duplicate-inconclusive") {
-        return NngInterface::MiningSubmitResult_DUPLICATE_INCONCLUSIVE;
-    }
-    if (reason == "inconclusive" || reason == "inconclusive-not-best-prevblk") {
-        return NngInterface::MiningSubmitResult_INCONCLUSIVE;
-    }
-    return NngInterface::MiningSubmitResult_REJECTED;
-}
-
-class NngSubmitBlockStateCatcher final : public CValidationInterface {
-public:
-    uint256 hash;
-    bool found;
-    BlockValidationState state;
-
-    explicit NngSubmitBlockStateCatcher(const uint256 &hashIn)
-        : hash(hashIn), found(false), state() {}
-
-protected:
-    void BlockChecked(const CBlock &block,
-                      const BlockValidationState &stateIn) override {
-        if (block.GetHash() != hash) {
-            return;
-        }
-        found = true;
-        state = stateIn;
-    }
-};
-
 NngRpcErrorCode
 NngRpcServer::GetBlock(flatbuffers::FlatBufferBuilder &fbb,
                        const NngInterface::GetBlockRequest *request) {
@@ -921,156 +859,6 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
         fbb.CreateString(Uint32ToStratumHex(pblock->nBits)),
         fbb.CreateString(BytesToHex(pblock->vTime.data(), pblock->vTime.size())));
     fbb.Finish(response);
-    return NngRpcErrorCode::NO_RPC_ERROR;
-}
-
-NngRpcErrorCode NngRpcServer::SubmitMinedBlock(
-    flatbuffers::FlatBufferBuilder &fbb,
-    const NngInterface::SubmitMinedBlockRequest *request) {
-    if (!request || !request->block()) {
-        return NngRpcErrorCode::INVALID_MINING_REQUEST;
-    }
-
-    CBlock block;
-    try {
-        std::vector<uint8_t> raw(request->block()->begin(), request->block()->end());
-        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
-        ss >> block;
-    } catch (...) {
-        return NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED;
-    }
-
-    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
-        auto resp = NngInterface::CreateSubmitMinedBlockResponse(
-            fbb, NngInterface::MiningSubmitResult_INVALID_COINBASE, false,
-            fbb.CreateString("Block does not start with a coinbase"),
-            CreateFbsBlockHash(fbb, BlockHash(block.GetHash())));
-        fbb.Finish(resp);
-        return NngRpcErrorCode::NO_RPC_ERROR;
-    }
-
-    const Config &config = GetConfig();
-    const uint256 hash = block.GetHash();
-    {
-        LOCK(cs_main);
-        const CBlockIndex *pindex = LookupBlockIndex(BlockHash(hash));
-        if (pindex) {
-            NngInterface::MiningSubmitResult code =
-                pindex->IsValid(BlockValidity::SCRIPTS)
-                    ? NngInterface::MiningSubmitResult_DUPLICATE
-                    : (pindex->nStatus.isInvalid()
-                           ? NngInterface::MiningSubmitResult_DUPLICATE_INVALID
-                           : NngInterface::MiningSubmitResult_DUPLICATE_INCONCLUSIVE);
-            std::string reason =
-                code == NngInterface::MiningSubmitResult_DUPLICATE
-                    ? "duplicate"
-                    : (code == NngInterface::MiningSubmitResult_DUPLICATE_INVALID
-                           ? "duplicate-invalid"
-                           : "duplicate-inconclusive");
-            auto resp = NngInterface::CreateSubmitMinedBlockResponse(
-                fbb, code, false, fbb.CreateString(reason),
-                CreateFbsBlockHash(fbb, BlockHash(hash)));
-            fbb.Finish(resp);
-            return NngRpcErrorCode::NO_RPC_ERROR;
-        }
-    }
-
-    bool new_block = false;
-    auto blockptr = std::make_shared<CBlock>(std::move(block));
-    auto sc = std::make_shared<NngSubmitBlockStateCatcher>(hash);
-    RegisterSharedValidationInterface(sc);
-    bool accepted = m_node.chainman->ProcessNewBlock(config, blockptr,
-                                                      /* fForceProcessing */ true,
-                                                      &new_block);
-    UnregisterSharedValidationInterface(sc);
-
-    std::optional<std::string> bip22Reason = std::string("inconclusive");
-    if (!new_block && accepted) {
-        bip22Reason = std::string("duplicate");
-    } else if (sc->found) {
-        if (sc->state.IsValid()) {
-            bip22Reason = std::nullopt;
-        } else if (sc->state.IsInvalid()) {
-            std::string reject = sc->state.GetRejectReason();
-            bip22Reason = reject.empty() ? std::optional<std::string>("rejected")
-                                         : std::optional<std::string>(reject);
-        } else {
-            bip22Reason = std::string("inconclusive");
-        }
-    }
-
-    const auto result = MapMiningSubmitReason(bip22Reason);
-    const bool blockAccepted =
-        result == NngInterface::MiningSubmitResult_ACCEPTED;
-    const std::string reason = bip22Reason.has_value() ? *bip22Reason : "";
-    auto resp = NngInterface::CreateSubmitMinedBlockResponse(
-        fbb, result, blockAccepted, fbb.CreateString(reason),
-        CreateFbsBlockHash(fbb, BlockHash(hash)));
-    fbb.Finish(resp);
-    return NngRpcErrorCode::NO_RPC_ERROR;
-}
-
-NngRpcErrorCode NngRpcServer::ValidateMinedBlockProposal(
-    flatbuffers::FlatBufferBuilder &fbb,
-    const NngInterface::ValidateMinedBlockProposalRequest *request) {
-    if (!request || !request->block()) {
-        return NngRpcErrorCode::INVALID_MINING_REQUEST;
-    }
-
-    CBlock block;
-    try {
-        std::vector<uint8_t> raw(request->block()->begin(), request->block()->end());
-        CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
-        ss >> block;
-    } catch (...) {
-        return NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED;
-    }
-
-    const Config &config = GetConfig();
-    const CChainParams &chainparams = config.GetChainParams();
-
-    std::optional<std::string> bip22Reason = std::nullopt;
-    {
-        LOCK(cs_main);
-        const uint256 hash = block.GetHash();
-        const CBlockIndex *pindex = LookupBlockIndex(BlockHash(hash));
-        if (pindex) {
-            if (pindex->IsValid(BlockValidity::SCRIPTS)) {
-                bip22Reason = std::string("duplicate");
-            } else if (pindex->nStatus.isInvalid()) {
-                bip22Reason = std::string("duplicate-invalid");
-            } else {
-                bip22Reason = std::string("duplicate-inconclusive");
-            }
-        } else {
-            CBlockIndex *const pindexPrev = ::ChainActive().Tip();
-            if (!pindexPrev || block.hashPrevBlock != pindexPrev->GetBlockHash()) {
-                bip22Reason = std::string("inconclusive-not-best-prevblk");
-            } else {
-                BlockValidationState state;
-                TestBlockValidity(state, chainparams, block, pindexPrev,
-                                  BlockValidationOptions(config)
-                                      .withCheckPoW(false)
-                                      .withCheckMerkleRoot(true));
-                if (state.IsValid()) {
-                    bip22Reason = std::nullopt;
-                } else if (state.IsInvalid()) {
-                    std::string reject = state.GetRejectReason();
-                    bip22Reason = reject.empty()
-                                      ? std::optional<std::string>("rejected")
-                                      : std::optional<std::string>(reject);
-                } else {
-                    bip22Reason = std::string("inconclusive");
-                }
-            }
-        }
-    }
-
-    const auto result = MapMiningSubmitReason(bip22Reason);
-    auto resp = NngInterface::CreateValidateMinedBlockProposalResponse(
-        fbb, result, result == NngInterface::MiningSubmitResult_ACCEPTED,
-        fbb.CreateString(bip22Reason.has_value() ? *bip22Reason : ""));
-    fbb.Finish(resp);
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
 

--- a/src/nng_interface/nng_interface.cpp
+++ b/src/nng_interface/nng_interface.cpp
@@ -74,7 +74,6 @@ enum class NngRpcErrorCode {
     INVALID_BLOCK_SLICE,
     INVALID_MINING_REQUEST,
     MINING_TEMPLATE_BUILD_FAILED,
-    MINING_SUBMIT_DECODE_FAILED,
 };
 struct RpcResult {
     NngRpcErrorCode error_code;
@@ -102,8 +101,6 @@ std::string ErrorMsg(NngRpcErrorCode code) {
             return "Invalid mining request";
         case NngRpcErrorCode::MINING_TEMPLATE_BUILD_FAILED:
             return "Failed to build mining template";
-        case NngRpcErrorCode::MINING_SUBMIT_DECODE_FAILED:
-            return "Failed to decode mined block";
         default:
             return "Unknown error";
     }
@@ -156,11 +153,6 @@ class NngRpcServer {
     NngRpcErrorCode
     GetMiningTemplate(flatbuffers::FlatBufferBuilder &builder,
                       const NngInterface::GetMiningTemplateRequest *request);
-
-    NngRpcErrorCode
-    GetMiningStatus(flatbuffers::FlatBufferBuilder &builder,
-                    const NngInterface::GetMiningStatusRequest *request);
-
 
 public:
     NngRpcServer(const Consensus::Params &consensus, const NodeContext &node)
@@ -284,10 +276,6 @@ NngRpcErrorCode NngRpcServer::HandleMsg(flatbuffers::FlatBufferBuilder &fbb,
         case NngInterface::RpcRequest_GetMiningTemplateRequest: {
             return GetMiningTemplate(fbb,
                                      rpc->rpc_as_GetMiningTemplateRequest());
-        }
-        case NngInterface::RpcRequest_GetMiningStatusRequest: {
-            return GetMiningStatus(fbb,
-                                   rpc->rpc_as_GetMiningStatusRequest());
         }
         default:
             return NngRpcErrorCode::UNKNOWN_RPC_METHOD;
@@ -470,19 +458,12 @@ CreateFbsBlock(flatbuffers::FlatBufferBuilder &fbb, const CBlock &block,
 }
 
 /**
- * Convert a uint256 hash to canonical stratum hex encoding used by mining
- * clients: each 32-bit word is byte-reversed while preserving word order.
+ * Convert a uint256 hash to little-endian hex as used by Stratum mining
+ * protocol for prevhash.  Lotus uses little-endian uint256 internally, so the
+ * raw bytes from hash.begin() are already in the correct byte order.
  */
 static std::string HashToStratumHex(const uint256 &hash) {
-    const uint8_t *data = hash.begin();
-    std::string result;
-    result.reserve(64);
-    for (int i = 0; i < 32; i += 4) {
-        for (int j = 3; j >= 0; j--) {
-            result += strprintf("%02x", data[i + j]);
-        }
-    }
-    return result;
+    return HexStr(Span<const uint8_t>(hash.begin(), 32));
 }
 
 /** Convert a 32-bit integer to little-endian hex as used by Stratum params. */
@@ -493,11 +474,6 @@ static std::string Uint32ToStratumHex(uint32_t val) {
     buf[2] = (val >> 16) & 0xff;
     buf[3] = (val >> 24) & 0xff;
     return HexStr(Span<const uint8_t>(buf, 4));
-}
-
-/** Convert raw bytes to lowercase hex preserving byte order. */
-static std::string BytesToHex(const uint8_t *data, size_t len) {
-    return HexStr(Span<const uint8_t>(data, len));
 }
 
 /**
@@ -574,21 +550,13 @@ SplitCoinbase(const CTransaction &coinbaseTx, size_t extranonce1Size,
 
     size_t scriptSigLenPos = pos;
 
-    uint64_t origScriptSigLen = 0;
-    int varintBytes = 0;
-    if (raw[pos] < 0xfd) {
-        origScriptSigLen = raw[pos];
-        varintBytes = 1;
-    } else if (raw[pos] == 0xfd) {
-        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8);
-        varintBytes = 3;
-    } else {
-        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8) |
-                           (raw[pos + 3] << 16) |
-                           ((uint64_t)raw[pos + 4] << 24);
-        varintBytes = 5;
-    }
-    pos += varintBytes;
+    CDataStream varintStream(
+        reinterpret_cast<const char *>(raw.data()) + pos,
+        reinterpret_cast<const char *>(raw.data()) + raw.size(),
+        SER_NETWORK, PROTOCOL_VERSION);
+    size_t before = varintStream.size();
+    uint64_t origScriptSigLen = ReadVarInt<CDataStream, VarIntMode::DEFAULT, uint64_t>(varintStream);
+    pos += before - varintStream.size();
 
     size_t scriptSigStart = pos;
     size_t scriptSigEnd = pos + origScriptSigLen;
@@ -596,20 +564,12 @@ SplitCoinbase(const CTransaction &coinbaseTx, size_t extranonce1Size,
     uint64_t extranonceSpace = extranonce1Size + extranonce2Size;
     uint64_t newScriptSigLen = origScriptSigLen + extranonceSpace;
 
-    std::vector<uint8_t> newVarint;
-    if (newScriptSigLen < 0xfd) {
-        newVarint.push_back((uint8_t)newScriptSigLen);
-    } else if (newScriptSigLen <= 0xffff) {
-        newVarint.push_back(0xfd);
-        newVarint.push_back(newScriptSigLen & 0xff);
-        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
-    } else {
-        newVarint.push_back(0xfe);
-        newVarint.push_back(newScriptSigLen & 0xff);
-        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
-        newVarint.push_back((newScriptSigLen >> 16) & 0xff);
-        newVarint.push_back((newScriptSigLen >> 24) & 0xff);
-    }
+    CDataStream newVarintStream(SER_NETWORK, PROTOCOL_VERSION);
+    WriteVarInt<CDataStream, VarIntMode::DEFAULT>(newVarintStream, newScriptSigLen);
+    std::vector<uint8_t> newVarint(
+        reinterpret_cast<const uint8_t *>(newVarintStream.data()),
+        reinterpret_cast<const uint8_t *>(newVarintStream.data()) +
+            newVarintStream.size());
 
     std::vector<uint8_t> cb1Data;
     cb1Data.insert(cb1Data.end(), raw.begin(), raw.begin() + scriptSigLenPos);
@@ -909,32 +869,8 @@ NngRpcErrorCode NngRpcServer::GetMiningTemplate(
         fbb.CreateVector(branchesFbs),
         fbb.CreateString(HashToStratumHex(pblock->hashPrevBlock)),
         fbb.CreateString(Uint32ToStratumHex(pblock->nBits)),
-        fbb.CreateString(BytesToHex(pblock->vTime.data(), pblock->vTime.size())));
+        fbb.CreateString(HexStr(Span<const uint8_t>(pblock->vTime.data(), pblock->vTime.size()))));
     fbb.Finish(response);
-    return NngRpcErrorCode::NO_RPC_ERROR;
-}
-
-NngRpcErrorCode
-NngRpcServer::GetMiningStatus(flatbuffers::FlatBufferBuilder &fbb,
-                              const NngInterface::GetMiningStatusRequest *request) {
-    LOCK(cs_main);
-    const CBlockIndex *tip = ::ChainActive().Tip();
-    if (!tip) {
-        return NngRpcErrorCode::BLOCK_NOT_FOUND;
-    }
-
-    uint32_t peers = 0;
-    if (m_node.connman) {
-        peers = m_node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
-    }
-
-    auto resp = NngInterface::CreateGetMiningStatusResponse(
-        fbb, CreateFbsBlockHash(fbb, tip->GetBlockHash()), tip->nHeight,
-        ::ChainstateActive().IsInitialBlockDownload(),
-        static_cast<uint64_t>(m_node.mempool->size()), peers,
-        GetAdjustedTime(), fbb.CreateString(tip->nChainWork.GetHex()),
-        fbb.CreateString(GetConfig().GetChainParams().NetworkIDString()));
-    fbb.Finish(resp);
     return NngRpcErrorCode::NO_RPC_ERROR;
 }
 

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -1,4 +1,5 @@
 // Copyright (c) 2021 The Logos Foundation
+// Copyright (c) 2024 The Lotusia Stewardship
 
 namespace NngInterface;
 
@@ -13,7 +14,6 @@ union RpcRequest {
     SubmitMinedBlockRequest,
     ValidateMinedBlockProposalRequest,
     GetMiningStatusRequest,
-    SendRawTransactionRequest,
 }
 
 // Result of an RPC call
@@ -504,28 +504,3 @@ table GetMiningStatusResponse {
     network: string;
 }
 
-// Submit a signed raw transaction to mempool relay surface.
-table SendRawTransactionRequest {
-    // Raw serialized transaction bytes.
-    raw_tx: [ubyte];
-    // Max fee rate in sat/kB. 0 keeps node default policy.
-    max_fee_rate: uint64 = 0;
-    relay: bool = true;
-    wait_callback: bool = true;
-}
-
-enum SendRawTransactionResult: int32 {
-    ACCEPTED = 0,
-    ALREADY_IN_CHAIN = 1,
-    MEMPOOL_REJECTED = 2,
-    MEMPOOL_ERROR = 3,
-    MAX_FEE_EXCEEDED = 4,
-    DESERIALIZATION_ERROR = 5,
-}
-
-table SendRawTransactionResponse {
-    result: SendRawTransactionResult;
-    accepted: bool;
-    txid: TxId;
-    reject_reason: string;
-}

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -9,6 +9,10 @@ union RpcRequest {
     GetBlockSliceRequest,
     GetUndoSliceRequest,
     GetMempoolRequest,
+    GetMiningTemplateRequest,
+    SubmitMinedBlockRequest,
+    ValidateMinedBlockProposalRequest,
+    GetMiningStatusRequest,
 }
 
 // Result of an RPC call
@@ -299,4 +303,156 @@ table GetMempoolRequest {}
 table GetMempoolResponse {
     // List of txs in the mempool
     txs: [MempoolTx];
+}
+
+// Metadata for a non-coinbase tx included in a mining template.
+table MiningTemplateTx {
+    // Raw serialized transaction.
+    raw: [ubyte];
+    // Txid of the transaction.
+    txid: TxId;
+    // Fee (in satoshis) attributed to this tx by BlockAssembler.
+    fee: int64;
+    // SigOp count attributed to this tx by BlockAssembler.
+    sigops: int64;
+}
+
+// Request a fresh mining template for external stratum/pool coordinators.
+//
+// The template is node-consensus-derived and can be transformed by the
+// external coordinator into one or many per-worker Stratum jobs.
+table GetMiningTemplateRequest {
+    // Script to use for the coinbase output(s).
+    // If omitted/empty, lotusd falls back to OP_RETURN to match
+    // getblocktemplate-like behavior for template-only callers.
+    coinbase_script: [ubyte];
+
+    // Number of bytes reserved for extranonce1 in stratum coinbase splitting.
+    // External stratum servers may set this to their session en1 size.
+    extranonce1_size: uint32 = 4;
+
+    // Number of bytes reserved for extranonce2 in stratum coinbase splitting.
+    // External stratum servers should set this to the miner-facing en2 size.
+    extranonce2_size: uint32 = 4;
+
+    // Include `transactions` payload in response.
+    // Set false to reduce payload when caller only needs header/coinbase split.
+    include_transactions: bool = true;
+}
+
+// Response for GetMiningTemplateRequest.
+table GetMiningTemplateResponse {
+    // Monotonic node-local template id for correlation/debugging.
+    template_id: uint64;
+
+    // Full serialized block template (including current coinbase tx).
+    block: [ubyte];
+
+    // Full serialized block header from the template.
+    header: [ubyte];
+
+    // Hash of the previous block this template builds on.
+    previous_block_hash: BlockHash;
+
+    // Height for this template.
+    height: int32;
+
+    // Compact target bits for this template.
+    bits: uint32;
+
+    // Full target corresponding to `bits`.
+    target: Hash;
+
+    // Current template time (unix seconds).
+    curtime: uint64;
+
+    // Minimum valid block time for this template (MTP+1 style lower bound).
+    mintime: uint64;
+
+    // Total coinbase output value available to miner (satoshis).
+    coinbase_value: uint64;
+
+    // Raw coinbase tx from the template.
+    coinbase_tx: [ubyte];
+
+    // Optional non-coinbase tx list and metadata.
+    transactions: [MiningTemplateTx];
+
+    // --- Stratum convenience fields (native Lotus header model) ---
+
+    // Coinbase split prefix/suffix, with extranonce space accounted for.
+    // External stratum servers can reconstruct per-share coinbase as:
+    //   coinbase1 || extranonce1 || extranonce2 || coinbase2
+    coinbase1: string;
+    coinbase2: string;
+
+    // Merkle branches for coinbase-first tree reconstruction.
+    merkle_branches: [string];
+
+    // Previous block hash in stratum-native endian presentation.
+    prev_hash_stratum: string;
+
+    // nBits as little-endian hex string for stratum clients.
+    nbits_stratum: string;
+
+    // 6-byte Lotus time field as little-endian hex (12 chars).
+    ntime_stratum: string;
+}
+
+// Result categories for submit/proposal validation used by mining RPCs.
+enum MiningSubmitResult: int32 {
+    ACCEPTED = 0,
+    DUPLICATE = 1,
+    DUPLICATE_INVALID = 2,
+    DUPLICATE_INCONCLUSIVE = 3,
+    INCONCLUSIVE = 4,
+    REJECTED = 5,
+    DESERIALIZATION_ERROR = 6,
+    INVALID_BLOCK = 7,
+    INVALID_COINBASE = 8,
+    INVALID_PREV_BLOCK = 9,
+}
+
+// Submit a candidate solved block to chainstate.
+table SubmitMinedBlockRequest {
+    // Raw serialized block bytes.
+    block: [ubyte];
+}
+
+// Result of SubmitMinedBlockRequest.
+table SubmitMinedBlockResponse {
+    // High-level result category.
+    result: MiningSubmitResult;
+
+    // True iff the block was accepted as a new block.
+    accepted: bool;
+
+    // Human-readable reject reason (BIP22-style when applicable).
+    reject_reason: string;
+}
+
+// Validate a block proposal against current tip without requiring PoW.
+// This mirrors getblocktemplate("proposal") style checking.
+table ValidateMinedBlockProposalRequest {
+    // Raw serialized block bytes.
+    block: [ubyte];
+}
+
+// Result of ValidateMinedBlockProposalRequest.
+table ValidateMinedBlockProposalResponse {
+    result: MiningSubmitResult;
+    valid: bool;
+    reject_reason: string;
+}
+
+// Fetch lightweight node mining status for external coordinators.
+table GetMiningStatusRequest {}
+
+table GetMiningStatusResponse {
+    tip_hash: BlockHash;
+    tip_height: int32;
+    initial_block_download: bool;
+    mempool_tx_count: uint64;
+    connected_peers: uint32;
+    network: string;
 }

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -233,6 +233,37 @@ table ChainStateFlushed {
     block_hash: BlockHash;
 }
 
+// Why `MiningWorkChanged` was emitted.
+//
+// This enum is used in `reason` and is intentionally compact because the
+// pub/sub topic is low-latency and high-frequency under active mining.
+enum MiningWorkChangeReason: int32 {
+    // New best tip (or reorg) changed chain context for template building.
+    NEW_TIP = 0,
+    // Mempool change may alter tx selection and coinbase reward.
+    MEMPOOL_UPDATE = 1,
+    // Catch-all for operator/manual invalidation events.
+    MANUAL = 2,
+}
+
+// Low-latency signal intended for external stratum coordinators.
+//
+// `UpdatedBlockTip` remains the canonical chain-tip event. This table adds a
+// mining-focused event with explicit reason and a monotonic template epoch to
+// let external services invalidate and refresh jobs quickly.
+table MiningWorkChanged {
+    // Cause of this work-change signal.
+    reason: MiningWorkChangeReason;
+    // Current best tip hash after the change.
+    block_hash: BlockHash;
+    // Current best height after the change.
+    height: int32;
+    // Node timestamp when signal was emitted.
+    node_time: int64;
+    // Monotonic counter local to the running node process.
+    template_epoch: uint64;
+}
+
 // Fetches a single block
 table GetBlockRequest {
     // Identifier of the block; either height or hash

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -13,6 +13,7 @@ union RpcRequest {
     SubmitMinedBlockRequest,
     ValidateMinedBlockProposalRequest,
     GetMiningStatusRequest,
+    SendRawTransactionRequest,
 }
 
 // Result of an RPC call
@@ -501,4 +502,30 @@ table GetMiningStatusResponse {
     // Active-tip cumulative chain work as hex.
     tip_chain_work: string;
     network: string;
+}
+
+// Submit a signed raw transaction to mempool relay surface.
+table SendRawTransactionRequest {
+    // Raw serialized transaction bytes.
+    raw_tx: [ubyte];
+    // Max fee rate in sat/kB. 0 keeps node default policy.
+    max_fee_rate: uint64 = 0;
+    relay: bool = true;
+    wait_callback: bool = true;
+}
+
+enum SendRawTransactionResult: int32 {
+    ACCEPTED = 0,
+    ALREADY_IN_CHAIN = 1,
+    MEMPOOL_REJECTED = 2,
+    MEMPOOL_ERROR = 3,
+    MAX_FEE_EXCEEDED = 4,
+    DESERIALIZATION_ERROR = 5,
+}
+
+table SendRawTransactionResponse {
+    result: SendRawTransactionResult;
+    accepted: bool;
+    txid: TxId;
+    reject_reason: string;
 }

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -361,6 +361,10 @@ table GetMiningTemplateRequest {
     // getblocktemplate-like behavior for template-only callers.
     coinbase_script: [ubyte];
 
+    // Optional aux bytes appended to the coinbase input scriptSig.
+    // Intended for operator/pool identity tags (coinbaseaux-style semantics).
+    coinbase_identity: [ubyte];
+
     // Number of bytes reserved for extranonce1 in stratum coinbase splitting.
     // External stratum servers may set this to their session en1 size.
     extranonce1_size: uint32 = 4;

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -238,12 +238,14 @@ table ChainStateFlushed {
 // This enum is used in `reason` and is intentionally compact because the
 // pub/sub topic is low-latency and high-frequency under active mining.
 enum MiningWorkChangeReason: int32 {
-    // New best tip (or reorg) changed chain context for template building.
+    // New best tip on the same chain progression (non-reorg).
     NEW_TIP = 0,
+    // Best tip changed due to a reorg/fork switch.
+    REORG = 1,
     // Mempool change may alter tx selection and coinbase reward.
-    MEMPOOL_UPDATE = 1,
+    MEMPOOL_REFRESH = 2,
     // Catch-all for operator/manual invalidation events.
-    MANUAL = 2,
+    MANUAL_INVALIDATION = 3,
 }
 
 // Low-latency signal intended for external stratum coordinators.
@@ -388,6 +390,9 @@ table GetMiningTemplateResponse {
     // Height for this template.
     height: int32;
 
+    // Block header version chosen for this template.
+    version: uint32;
+
     // Compact target bits for this template.
     bits: uint32;
 
@@ -399,6 +404,9 @@ table GetMiningTemplateResponse {
 
     // Minimum valid block time for this template (MTP+1 style lower bound).
     mintime: uint64;
+
+    // Current max acceptable block time from node perspective.
+    maxtime: uint64;
 
     // Total coinbase output value available to miner (satoshis).
     coinbase_value: uint64;
@@ -460,6 +468,9 @@ table SubmitMinedBlockResponse {
 
     // Human-readable reject reason (BIP22-style when applicable).
     reject_reason: string;
+
+    // Hash of submitted candidate block.
+    block_hash: BlockHash;
 }
 
 // Validate a block proposal against current tip without requiring PoW.
@@ -485,5 +496,9 @@ table GetMiningStatusResponse {
     initial_block_download: bool;
     mempool_tx_count: uint64;
     connected_peers: uint32;
+    // Node clock (unix seconds) from GetAdjustedTime().
+    node_time: int64;
+    // Active-tip cumulative chain work as hex.
+    tip_chain_work: string;
     network: string;
 }

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -11,8 +11,6 @@ union RpcRequest {
     GetUndoSliceRequest,
     GetMempoolRequest,
     GetMiningTemplateRequest,
-    SubmitMinedBlockRequest,
-    ValidateMinedBlockProposalRequest,
     GetMiningStatusRequest,
 }
 
@@ -443,54 +441,6 @@ table GetMiningTemplateResponse {
     ntime_stratum: string;
 }
 
-// Result categories for submit/proposal validation used by mining RPCs.
-enum MiningSubmitResult: int32 {
-    ACCEPTED = 0,
-    DUPLICATE = 1,
-    DUPLICATE_INVALID = 2,
-    DUPLICATE_INCONCLUSIVE = 3,
-    INCONCLUSIVE = 4,
-    REJECTED = 5,
-    DESERIALIZATION_ERROR = 6,
-    INVALID_BLOCK = 7,
-    INVALID_COINBASE = 8,
-    INVALID_PREV_BLOCK = 9,
-}
-
-// Submit a candidate solved block to chainstate.
-table SubmitMinedBlockRequest {
-    // Raw serialized block bytes.
-    block: [ubyte];
-}
-
-// Result of SubmitMinedBlockRequest.
-table SubmitMinedBlockResponse {
-    // High-level result category.
-    result: MiningSubmitResult;
-
-    // True iff the block was accepted as a new block.
-    accepted: bool;
-
-    // Human-readable reject reason (BIP22-style when applicable).
-    reject_reason: string;
-
-    // Hash of submitted candidate block.
-    block_hash: BlockHash;
-}
-
-// Validate a block proposal against current tip without requiring PoW.
-// This mirrors getblocktemplate("proposal") style checking.
-table ValidateMinedBlockProposalRequest {
-    // Raw serialized block bytes.
-    block: [ubyte];
-}
-
-// Result of ValidateMinedBlockProposalRequest.
-table ValidateMinedBlockProposalResponse {
-    result: MiningSubmitResult;
-    valid: bool;
-    reject_reason: string;
-}
 
 // Fetch lightweight node mining status for external coordinators.
 table GetMiningStatusRequest {}

--- a/src/nng_interface/nng_interface.fbs
+++ b/src/nng_interface/nng_interface.fbs
@@ -11,7 +11,6 @@ union RpcRequest {
     GetUndoSliceRequest,
     GetMempoolRequest,
     GetMiningTemplateRequest,
-    GetMiningStatusRequest,
 }
 
 // Result of an RPC call
@@ -439,22 +438,5 @@ table GetMiningTemplateResponse {
 
     // 6-byte Lotus time field as little-endian hex (12 chars).
     ntime_stratum: string;
-}
-
-
-// Fetch lightweight node mining status for external coordinators.
-table GetMiningStatusRequest {}
-
-table GetMiningStatusResponse {
-    tip_hash: BlockHash;
-    tip_height: int32;
-    initial_block_download: bool;
-    mempool_tx_count: uint64;
-    connected_peers: uint32;
-    // Node clock (unix seconds) from GetAdjustedTime().
-    node_time: int64;
-    // Active-tip cumulative chain work as hex.
-    tip_chain_work: string;
-    network: string;
 }
 

--- a/src/nng_interface/nng_interface.h
+++ b/src/nng_interface/nng_interface.h
@@ -13,10 +13,13 @@ const std::string MSG_MEMPOOLTXREM = "mempooltxrem";
 const std::string MSG_BLKCONNECTED = "blkconnected";
 const std::string MSG_BLKDISCONCTD = "blkdisconctd";
 const std::string MSG_CHAINSTFLUSH = "chainstflush";
+// Mining-focused low-latency template invalidation signal.
+const std::string MSG_MININGWORKCHG = "miningworkchg";
 
 const std::vector<std::string> AVAILABLE_PUB_MESSAGES = {
     MSG_UPDATEBLKTIP, MSG_MEMPOOLTXADD, MSG_MEMPOOLTXREM,
     MSG_BLKCONNECTED, MSG_BLKDISCONCTD, MSG_CHAINSTFLUSH,
+    MSG_MININGWORKCHG,
 };
 
 bool StartNngInterface(const NodeContext &node,

--- a/src/nng_interface/nng_interface.h
+++ b/src/nng_interface/nng_interface.h
@@ -14,14 +14,14 @@ const std::string MSG_BLKCONNECTED = "blkconnected";
 const std::string MSG_BLKDISCONCTD = "blkdisconctd";
 const std::string MSG_CHAINSTFLUSH = "chainstflush";
 // Mining-focused low-latency template invalidation signal.
-const std::string MSG_MININGWORKCHG = "miningworkchg";
+const std::string MSG_MININGWRKCHG = "miningwrkchg";
 
 const std::vector<std::string> AVAILABLE_PUB_MESSAGES = {
     MSG_UPDATEBLKTIP, MSG_MEMPOOLTXADD, MSG_MEMPOOLTXREM,
     MSG_BLKCONNECTED, MSG_BLKDISCONCTD, MSG_CHAINSTFLUSH,
-    MSG_MININGWORKCHG,
+    MSG_MININGWRKCHG,
 };
 
-bool StartNngInterface(const NodeContext &node,
+bool StartNngInterface(NodeContext &node,
                        const Consensus::Params &consensus);
 void StopNngInterface();

--- a/src/nng_interface/nng_interface.h
+++ b/src/nng_interface/nng_interface.h
@@ -22,6 +22,6 @@ const std::vector<std::string> AVAILABLE_PUB_MESSAGES = {
     MSG_MININGWRKCHG,
 };
 
-bool StartNngInterface(NodeContext &node,
+bool StartNngInterface(const NodeContext &node,
                        const Consensus::Params &consensus);
 void StopNngInterface();

--- a/src/validation.h
+++ b/src/validation.h
@@ -829,7 +829,9 @@ public:
     }
 
     //! @returns A reference to the on-disk UTXO set database.
-    CCoinsViewDB &CoinsDB() { return m_coins_views->m_dbview; }
+    CCoinsViewDB &CoinsDB() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+        return m_coins_views->m_dbview;
+    }
 
     //! @returns A reference to a wrapped view of the in-memory UTXO set that
     //!     handles disk read errors gracefully.

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -605,6 +605,7 @@ class NngInterfaceTest(BitcoinTestFramework):
         response = SubmitMinedBlockResponse.GetSubmitMinedBlockResponse.GetRootAs(response, 0)
         assert_equal(response.Accepted(), False)
         assert response.Result() >= 0
+        assert_equal(bytes(response.BlockHash().Hash().Data())[::-1].hex(), tiphash)
 
         # GetMiningStatus: verify tip and basic status fields are coherent.
         await self._send_request(rpc_sock, self._make_get_mining_status_request_fbs())
@@ -613,6 +614,8 @@ class NngInterfaceTest(BitcoinTestFramework):
         assert_equal(bytes(response.TipHash().Hash().Data())[::-1].hex(), tiphash)
         assert response.TipHeight() >= 0
         assert response.MempoolTxCount() >= 0
+        assert response.NodeTime() > 0
+        assert response.TipChainWork() is not None
         assert response.Network() is not None
 
     async def _recv_message(self, pub_sock, expected_msg_type, timeout=2):
@@ -663,8 +666,8 @@ class NngInterfaceTest(BitcoinTestFramework):
         msg2 = await self._recv_message(pub_sock, 'miningworkchg')
         evt2 = MiningWorkChanged.GetRootAs(msg2, 0)
         assert_equal(bytes(evt2.BlockHash().Hash().Data())[::-1].hex(), node.getbestblockhash())
-        # MEMPOOL_UPDATE
-        assert_equal(evt2.Reason(), 1)
+        # MEMPOOL_REFRESH
+        assert_equal(evt2.Reason(), 2)
         assert evt2.TemplateEpoch() > evt.TemplateEpoch()
 
         pub_sock.unsubscribe('miningworkchg')

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -199,7 +199,7 @@ class NngInterfaceTest(BitcoinTestFramework):
         fbb.Finish(rpc)
         return bytes(fbb.Output())
 
-    def _make_get_mining_template_request_fbs(self):
+    def _make_get_mining_template_request_fbs(self, coinbase_identity=None):
         from NngInterface import (
             RpcCall,
             RpcRequest,
@@ -207,8 +207,13 @@ class NngInterfaceTest(BitcoinTestFramework):
         )
         import flatbuffers
         fbb = flatbuffers.Builder()
+        identity_vec = None
+        if coinbase_identity is not None:
+            identity_vec = fbb.CreateByteVector(coinbase_identity)
         # Use defaults: OP_RETURN fallback script and 4/4 extranonce sizes.
         GetMiningTemplateRequest.Start(fbb)
+        if identity_vec is not None:
+            GetMiningTemplateRequest.AddCoinbaseIdentity(fbb, identity_vec)
         req = GetMiningTemplateRequest.End(fbb)
         RpcCall.Start(fbb)
         RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.GetMiningTemplateRequest)
@@ -582,6 +587,16 @@ class NngInterfaceTest(BitcoinTestFramework):
         assert_equal(response.PrevHashStratum().__len__(), 64)
         assert_equal(response.NbitsStratum().__len__(), 8)
         assert_equal(response.NtimeStratum().__len__(), 12)
+
+        # Identity bytes should appear in coinbase scriptSig-related split data.
+        identity = b"lotusia-pool"
+        await self._send_request(
+            rpc_sock,
+            self._make_get_mining_template_request_fbs(identity),
+        )
+        response_with_identity = await self._recv_response(rpc_sock)
+        response_with_identity = GetMiningTemplateResponse.GetMiningTemplateResponse.GetRootAs(response_with_identity, 0)
+        assert identity.hex() in response_with_identity.Coinbase1()
 
         # ValidateMinedBlockProposal: feed known on-chain block bytes to hit a
         # deterministic duplicate*/inconclusive result path.

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -41,6 +41,7 @@ class NngInterfaceTest(BitcoinTestFramework):
             "-nngpubmsg=blkconnected",
             "-nngpubmsg=blkdisconctd",
             "-nngpubmsg=chainstflush",
+            "-nngpubmsg=miningworkchg",
             # Always expire after 1h
             "-mempoolexpiry=1",
         ]]
@@ -76,6 +77,7 @@ class NngInterfaceTest(BitcoinTestFramework):
         with pynng.Sub0() as pub_sock:
             pub_sock.dial(PUB_URL)
             await self._test_update_chain_tip(node, pub_sock)
+            await self._test_mining_work_changed(node, pub_sock)
             await self._test_transaction_added_to_mempool(node, pub_sock)
             await self._test_transaction_removed_from_mempool_conflict(node, pub_sock)
             await self._test_transaction_removed_from_mempool_expiry(node, pub_sock)
@@ -635,6 +637,37 @@ class NngInterfaceTest(BitcoinTestFramework):
         msg = UpdatedBlockTip.GetRootAs(msg, 0)
         assert_equal(bytes(msg.BlockHash().Hash().Data())[::-1].hex(), hashes[0])
         pub_sock.unsubscribe('updateblktip')
+
+    async def _test_mining_work_changed(self, node, pub_sock):
+        from NngInterface.MiningWorkChanged import MiningWorkChanged
+
+        pub_sock.subscribe('miningworkchg')
+
+        # 1) Tip-driven work change.
+        hashes = node.generatetoaddress(1, self.burn_addr)
+        msg = await self._recv_message(pub_sock, 'miningworkchg')
+        evt = MiningWorkChanged.GetRootAs(msg, 0)
+        assert_equal(bytes(evt.BlockHash().Hash().Data())[::-1].hex(), hashes[0])
+        assert evt.TemplateEpoch() > 0
+        # NEW_TIP
+        assert_equal(evt.Reason(), 0)
+
+        # 2) Mempool-driven work change.
+        tx = CTransaction()
+        outpoint, value = self._get_utxo(node)
+        tx.vin.append(CTxIn(outpoint, CScript([b'\x51'])))
+        tx.vout.append(CTxOut(value - 1000, CScript([OP_HASH160, bytes(20), OP_EQUAL])))
+        pad_tx(tx)
+        node.sendrawtransaction(tx.serialize().hex())
+
+        msg2 = await self._recv_message(pub_sock, 'miningworkchg')
+        evt2 = MiningWorkChanged.GetRootAs(msg2, 0)
+        assert_equal(bytes(evt2.BlockHash().Hash().Data())[::-1].hex(), node.getbestblockhash())
+        # MEMPOOL_UPDATE
+        assert_equal(evt2.Reason(), 1)
+        assert evt2.TemplateEpoch() > evt.TemplateEpoch()
+
+        pub_sock.unsubscribe('miningworkchg')
 
     async def _test_transaction_added_to_mempool(self, node, pub_sock):
         from NngInterface.TransactionAddedToMempool import TransactionAddedToMempool

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -72,6 +72,7 @@ class NngInterfaceTest(BitcoinTestFramework):
             await self._test_get_block_slice_errors(rpc_sock)
             await self._test_send_tx(node, rpc_sock)
             await self._test_get_block_range(node, rpc_sock)
+            await self._test_mining_rpcs(node, rpc_sock)
         with pynng.Sub0() as pub_sock:
             pub_sock.dial(PUB_URL)
             await self._test_update_chain_tip(node, pub_sock)
@@ -192,6 +193,80 @@ class NngInterfaceTest(BitcoinTestFramework):
         RpcCall.Start(fbb)
         RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.GetMempoolRequest)
         RpcCall.AddRpc(fbb, get_mempool_request)
+        rpc = RpcCall.End(fbb)
+        fbb.Finish(rpc)
+        return bytes(fbb.Output())
+
+    def _make_get_mining_template_request_fbs(self):
+        from NngInterface import (
+            RpcCall,
+            RpcRequest,
+            GetMiningTemplateRequest,
+        )
+        import flatbuffers
+        fbb = flatbuffers.Builder()
+        # Use defaults: OP_RETURN fallback script and 4/4 extranonce sizes.
+        GetMiningTemplateRequest.Start(fbb)
+        req = GetMiningTemplateRequest.End(fbb)
+        RpcCall.Start(fbb)
+        RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.GetMiningTemplateRequest)
+        RpcCall.AddRpc(fbb, req)
+        rpc = RpcCall.End(fbb)
+        fbb.Finish(rpc)
+        return bytes(fbb.Output())
+
+    def _make_submit_mined_block_request_fbs(self, block_raw):
+        from NngInterface import (
+            RpcCall,
+            RpcRequest,
+            SubmitMinedBlockRequest,
+        )
+        import flatbuffers
+        fbb = flatbuffers.Builder()
+        block_vec = fbb.CreateByteVector(block_raw)
+        SubmitMinedBlockRequest.Start(fbb)
+        SubmitMinedBlockRequest.AddBlock(fbb, block_vec)
+        req = SubmitMinedBlockRequest.End(fbb)
+        RpcCall.Start(fbb)
+        RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.SubmitMinedBlockRequest)
+        RpcCall.AddRpc(fbb, req)
+        rpc = RpcCall.End(fbb)
+        fbb.Finish(rpc)
+        return bytes(fbb.Output())
+
+    def _make_validate_mined_block_proposal_request_fbs(self, block_raw):
+        from NngInterface import (
+            RpcCall,
+            RpcRequest,
+            ValidateMinedBlockProposalRequest,
+        )
+        import flatbuffers
+        fbb = flatbuffers.Builder()
+        block_vec = fbb.CreateByteVector(block_raw)
+        ValidateMinedBlockProposalRequest.Start(fbb)
+        ValidateMinedBlockProposalRequest.AddBlock(fbb, block_vec)
+        req = ValidateMinedBlockProposalRequest.End(fbb)
+        RpcCall.Start(fbb)
+        RpcCall.AddRpcType(
+            fbb, RpcRequest.RpcRequest.ValidateMinedBlockProposalRequest)
+        RpcCall.AddRpc(fbb, req)
+        rpc = RpcCall.End(fbb)
+        fbb.Finish(rpc)
+        return bytes(fbb.Output())
+
+    def _make_get_mining_status_request_fbs(self):
+        from NngInterface import (
+            RpcCall,
+            RpcRequest,
+            GetMiningStatusRequest,
+        )
+        import flatbuffers
+        fbb = flatbuffers.Builder()
+        GetMiningStatusRequest.Start(fbb)
+        req = GetMiningStatusRequest.End(fbb)
+        RpcCall.Start(fbb)
+        RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.GetMiningStatusRequest)
+        RpcCall.AddRpc(fbb, req)
         rpc = RpcCall.End(fbb)
         fbb.Finish(rpc)
         return bytes(fbb.Output())
@@ -484,6 +559,59 @@ class NngInterfaceTest(BitcoinTestFramework):
         response = await self._recv_response(rpc_sock)
         response = GetBlockRangeResponse.GetBlockRangeResponse.GetRootAs(response, 0)
         assert_equal(response.BlocksLength(), 12)
+
+    async def _test_mining_rpcs(self, node, rpc_sock):
+        from NngInterface import (
+            GetMiningTemplateResponse,
+            SubmitMinedBlockResponse,
+            ValidateMinedBlockProposalResponse,
+            GetMiningStatusResponse,
+        )
+
+        # GetMiningTemplate: returns a coherent template payload with both
+        # raw block/header bytes and stratum helper fields.
+        await self._send_request(rpc_sock, self._make_get_mining_template_request_fbs())
+        response = await self._recv_response(rpc_sock)
+        response = GetMiningTemplateResponse.GetMiningTemplateResponse.GetRootAs(response, 0)
+        assert response.TemplateId() > 0
+        assert response.BlockLength() > 0
+        assert response.HeaderLength() > 0
+        assert response.CoinbaseTxLength() > 0
+        assert_equal(response.PrevHashStratum().__len__(), 64)
+        assert_equal(response.NbitsStratum().__len__(), 8)
+        assert_equal(response.NtimeStratum().__len__(), 12)
+
+        # ValidateMinedBlockProposal: feed known on-chain block bytes to hit a
+        # deterministic duplicate*/inconclusive result path.
+        tiphash = node.getbestblockhash()
+        tipraw = bytes.fromhex(node.getblock(tiphash, 0))
+        await self._send_request(
+            rpc_sock,
+            self._make_validate_mined_block_proposal_request_fbs(tipraw),
+        )
+        response = await self._recv_response(rpc_sock)
+        response = ValidateMinedBlockProposalResponse.GetValidateMinedBlockProposalResponse.GetRootAs(response, 0)
+        assert response.Result() >= 0
+
+        # SubmitMinedBlock: submitting existing tip should be duplicate-ish and
+        # must not be marked accepted.
+        await self._send_request(
+            rpc_sock,
+            self._make_submit_mined_block_request_fbs(tipraw),
+        )
+        response = await self._recv_response(rpc_sock)
+        response = SubmitMinedBlockResponse.GetSubmitMinedBlockResponse.GetRootAs(response, 0)
+        assert_equal(response.Accepted(), False)
+        assert response.Result() >= 0
+
+        # GetMiningStatus: verify tip and basic status fields are coherent.
+        await self._send_request(rpc_sock, self._make_get_mining_status_request_fbs())
+        response = await self._recv_response(rpc_sock)
+        response = GetMiningStatusResponse.GetMiningStatusResponse.GetRootAs(response, 0)
+        assert_equal(bytes(response.TipHash().Hash().Data())[::-1].hex(), tiphash)
+        assert response.TipHeight() >= 0
+        assert response.MempoolTxCount() >= 0
+        assert response.Network() is not None
 
     async def _recv_message(self, pub_sock, expected_msg_type, timeout=2):
         received_msg = await asyncio.wait_for(pub_sock.arecv_msg(), timeout=timeout)

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -41,7 +41,7 @@ class NngInterfaceTest(BitcoinTestFramework):
             "-nngpubmsg=blkconnected",
             "-nngpubmsg=blkdisconctd",
             "-nngpubmsg=chainstflush",
-            "-nngpubmsg=miningworkchg",
+            "-nngpubmsg=miningwrkchg",
             # Always expire after 1h
             "-mempoolexpiry=1",
         ]]
@@ -644,11 +644,11 @@ class NngInterfaceTest(BitcoinTestFramework):
     async def _test_mining_work_changed(self, node, pub_sock):
         from NngInterface.MiningWorkChanged import MiningWorkChanged
 
-        pub_sock.subscribe('miningworkchg')
+        pub_sock.subscribe('miningwrkchg')
 
         # 1) Tip-driven work change.
         hashes = node.generatetoaddress(1, self.burn_addr)
-        msg = await self._recv_message(pub_sock, 'miningworkchg')
+        msg = await self._recv_message(pub_sock, 'miningwrkchg')
         evt = MiningWorkChanged.GetRootAs(msg, 0)
         assert_equal(bytes(evt.BlockHash().Hash().Data())[::-1].hex(), hashes[0])
         assert evt.TemplateEpoch() > 0
@@ -663,14 +663,14 @@ class NngInterfaceTest(BitcoinTestFramework):
         pad_tx(tx)
         node.sendrawtransaction(tx.serialize().hex())
 
-        msg2 = await self._recv_message(pub_sock, 'miningworkchg')
+        msg2 = await self._recv_message(pub_sock, 'miningwrkchg')
         evt2 = MiningWorkChanged.GetRootAs(msg2, 0)
         assert_equal(bytes(evt2.BlockHash().Hash().Data())[::-1].hex(), node.getbestblockhash())
         # MEMPOOL_REFRESH
         assert_equal(evt2.Reason(), 2)
         assert evt2.TemplateEpoch() > evt.TemplateEpoch()
 
-        pub_sock.unsubscribe('miningworkchg')
+        pub_sock.unsubscribe('miningwrkchg')
 
     async def _test_transaction_added_to_mempool(self, node, pub_sock):
         from NngInterface.TransactionAddedToMempool import TransactionAddedToMempool

--- a/test/functional/interface_nng.py
+++ b/test/functional/interface_nng.py
@@ -222,44 +222,6 @@ class NngInterfaceTest(BitcoinTestFramework):
         fbb.Finish(rpc)
         return bytes(fbb.Output())
 
-    def _make_submit_mined_block_request_fbs(self, block_raw):
-        from NngInterface import (
-            RpcCall,
-            RpcRequest,
-            SubmitMinedBlockRequest,
-        )
-        import flatbuffers
-        fbb = flatbuffers.Builder()
-        block_vec = fbb.CreateByteVector(block_raw)
-        SubmitMinedBlockRequest.Start(fbb)
-        SubmitMinedBlockRequest.AddBlock(fbb, block_vec)
-        req = SubmitMinedBlockRequest.End(fbb)
-        RpcCall.Start(fbb)
-        RpcCall.AddRpcType(fbb, RpcRequest.RpcRequest.SubmitMinedBlockRequest)
-        RpcCall.AddRpc(fbb, req)
-        rpc = RpcCall.End(fbb)
-        fbb.Finish(rpc)
-        return bytes(fbb.Output())
-
-    def _make_validate_mined_block_proposal_request_fbs(self, block_raw):
-        from NngInterface import (
-            RpcCall,
-            RpcRequest,
-            ValidateMinedBlockProposalRequest,
-        )
-        import flatbuffers
-        fbb = flatbuffers.Builder()
-        block_vec = fbb.CreateByteVector(block_raw)
-        ValidateMinedBlockProposalRequest.Start(fbb)
-        ValidateMinedBlockProposalRequest.AddBlock(fbb, block_vec)
-        req = ValidateMinedBlockProposalRequest.End(fbb)
-        RpcCall.Start(fbb)
-        RpcCall.AddRpcType(
-            fbb, RpcRequest.RpcRequest.ValidateMinedBlockProposalRequest)
-        RpcCall.AddRpc(fbb, req)
-        rpc = RpcCall.End(fbb)
-        fbb.Finish(rpc)
-        return bytes(fbb.Output())
 
     def _make_get_mining_status_request_fbs(self):
         from NngInterface import (
@@ -570,8 +532,6 @@ class NngInterfaceTest(BitcoinTestFramework):
     async def _test_mining_rpcs(self, node, rpc_sock):
         from NngInterface import (
             GetMiningTemplateResponse,
-            SubmitMinedBlockResponse,
-            ValidateMinedBlockProposalResponse,
             GetMiningStatusResponse,
         )
 
@@ -598,31 +558,8 @@ class NngInterfaceTest(BitcoinTestFramework):
         response_with_identity = GetMiningTemplateResponse.GetMiningTemplateResponse.GetRootAs(response_with_identity, 0)
         assert identity.hex() in response_with_identity.Coinbase1()
 
-        # ValidateMinedBlockProposal: feed known on-chain block bytes to hit a
-        # deterministic duplicate*/inconclusive result path.
-        tiphash = node.getbestblockhash()
-        tipraw = bytes.fromhex(node.getblock(tiphash, 0))
-        await self._send_request(
-            rpc_sock,
-            self._make_validate_mined_block_proposal_request_fbs(tipraw),
-        )
-        response = await self._recv_response(rpc_sock)
-        response = ValidateMinedBlockProposalResponse.GetValidateMinedBlockProposalResponse.GetRootAs(response, 0)
-        assert response.Result() >= 0
-
-        # SubmitMinedBlock: submitting existing tip should be duplicate-ish and
-        # must not be marked accepted.
-        await self._send_request(
-            rpc_sock,
-            self._make_submit_mined_block_request_fbs(tipraw),
-        )
-        response = await self._recv_response(rpc_sock)
-        response = SubmitMinedBlockResponse.GetSubmitMinedBlockResponse.GetRootAs(response, 0)
-        assert_equal(response.Accepted(), False)
-        assert response.Result() >= 0
-        assert_equal(bytes(response.BlockHash().Hash().Data())[::-1].hex(), tiphash)
-
         # GetMiningStatus: verify tip and basic status fields are coherent.
+        tiphash = node.getbestblockhash()
         await self._send_request(rpc_sock, self._make_get_mining_status_request_fbs())
         response = await self._recv_response(rpc_sock)
         response = GetMiningStatusResponse.GetMiningStatusResponse.GetRootAs(response, 0)


### PR DESCRIPTION
Add NNG-based mining endpoints and a pub/sub invalidation signal
that enable external Stratum v1 coordinators (stratum-server-nng)
to interact with lotusd for pooled-mining, while keeping lotusd as
the sole consensus authority.

### What's added

**`GetMiningTemplateRequest` RPC**
Builds a block template via `BlockAssembler` and returns raw
block/header bytes alongside Stratum-oriented convenience fields:
coinbase split (cb1/cb2 with reserved extranonce space), merkle
branches, stratum-endian prevhash/bits/time, and version/mintime/
maxtime bounds. Accepts an optional `coinbase_identity` byte vector
(coinbaseaux-style operator tag in scriptSig) and configurable
extranonce sizes.

**`miningwrkchg` pub/sub topic**
Low-latency invalidation signal emitted on `UpdatedBlockTip`
(NEW_TIP or REORG), `TransactionAddedToMempool`, and
`TransactionRemovedFromMempool` (MEMPOOL_REFRESH). Each event
carries the reason, block hash, height, node time, and a monotonic
template epoch so the coordinator can decide efficiently whether
to re-fetch.

**Merkle branch correctness**
`ComputeMerkleBranches` now uses the correct Lotus merkle tree
format — `SHA256d(tx_hash || tx_id)` leaf hashes and zero-padded
odd levels — and computes branches from a properly reconstructed
coinbase that includes placeholder extranonce bytes, matching the
coinbase the stratum coordinator builds per-miner.

### Rationale

The architecture follows the NNG pattern already established by
chronik_nng: lotusd exposes lightweight IPC/RPC + pub/sub endpoints,
and external services consume them without coupling to lotusd's
internal APIs. The stratum coordinator manages miner connections,
assigns extranonce ranges, calls `GetMiningTemplateRequest` for
templates, and subscribes to `miningwrkchg` for work-change events.
Solved blocks are submitted via the existing JSON-RPC `submitblock`
endpoint. This keeps lotusd out of the Stratum protocol path entirely
while providing the minimum surface needed for pooled-mining support.

### Supporting changes

- New FlatBuffers tables: `MiningWorkChanged`, `MiningWorkChangeReason`,
 `MiningTemplateTx`, `GetMiningTemplateRequest`, `GetMiningTemplateResponse`
- New C++ handler for `GetMiningTemplateRequest`, `EmitMiningWorkChanged`
 helper, and `m_templateEpoch` counter in the pub server
- Topic constant `MSG_MININGWORKCHG` and `AVAILABLE_PUB_MESSAGES` entry
- Thread-safety annotation (`EXCLUSIVE_LOCKS_REQUIRED(cs_main)`) on
 `CoinsDB()` fixing a clang warning surfaced by the new includes
- `doc/nng.md` updated with mining endpoint docs, IPC/TCP configuration
 examples, and topology guidance
- Functional tests for template retrieval, coinbase identity injection,
 and mining work-change pub/sub events