### PR TITLE
 Consensus, init, net: address updates, project branding, miniupnpc compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            -t buster-backports cmake \
-            build-essential autoconf automake curl gperf git \
+            build-essential autoconf automake cmake curl gperf git \
             libtool ninja-build patch pkg-config python3
 
       - name: Build depends

--- a/contrib/utils/install-dependencies.sh
+++ b/contrib/utils/install-dependencies.sh
@@ -95,9 +95,10 @@ BACKPORTS=(
   shellcheck
 )
 
-echo "deb http://deb.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list
+echo "deb http://archive.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list
+echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get -t buster-backports install -y $(join_by ' ' "${BACKPORTS[@]}")
+DEBIAN_FRONTEND=noninteractive apt-get -t buster-backports install -y -o Acquire::Check-Valid-Until=false $(join_by ' ' "${BACKPORTS[@]}")
 
 
 # Install llvm-8 and clang-10

--- a/dockerfiles/Dockerfile.lotus
+++ b/dockerfiles/Dockerfile.lotus
@@ -1,23 +1,16 @@
 # Build stage
-FROM debian:buster AS builder
+FROM debian:bookworm AS builder
 
 # Prevent interactive prompts during apt-get install (e.g., tzdata)
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# Debian Buster is archived - use archive.debian.org repositories
-RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
-
-# Install CMake from buster-backports and build prerequisites in a single step
-# to avoid dependency conflicts (matches gitian build environment)
+# Install build prerequisites
 RUN apt-get update && apt-get install -y \
-    -t buster-backports cmake \
     build-essential \
     autoconf \
     automake \
+    cmake \
     curl \
     gperf \
     git \
@@ -54,17 +47,12 @@ RUN mkdir build && cd build && \
     ninja security-check && \
     ninja symbol-check
 
-# Runtime stage -- use debian:buster to match gitian build environment
-FROM debian:buster
+# Runtime stage
+FROM debian:bookworm-slim
 
 # Prevent interactive prompts during apt-get install
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
-
-# Debian Buster is archived - use archive.debian.org repositories
-RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
 
 # Install minimal runtime dependencies (depends system statically links most libs)
 RUN apt-get update && apt-get install -y \

--- a/dockerfiles/Dockerfile.lotus-qt
+++ b/dockerfiles/Dockerfile.lotus-qt
@@ -1,23 +1,16 @@
 # Build stage
-FROM debian:buster AS builder
+FROM debian:bookworm AS builder
 
 # Prevent interactive prompts during apt-get install (e.g., tzdata)
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# Debian Buster is archived - use archive.debian.org repositories
-RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
-
-# Install CMake from buster-backports and build prerequisites in a single step
-# to avoid dependency conflicts (matches gitian build environment)
+# Install build prerequisites
 RUN apt-get update && apt-get install -y \
-    -t buster-backports cmake \
     build-essential \
     autoconf \
     automake \
+    cmake \
     curl \
     gperf \
     git \
@@ -52,17 +45,12 @@ RUN mkdir build && cd build && \
     ninja security-check && \
     ninja symbol-check
 
-# Runtime stage -- use debian:buster to match gitian build environment
-FROM debian:buster
+# Runtime stage
+FROM debian:bookworm-slim
 
 # Prevent interactive prompts during apt-get install
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
-
-# Debian Buster is archived - use archive.debian.org repositories
-RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
 
 # Install minimal runtime dependencies (depends system statically links most libs)
 RUN apt-get update && apt-get install -y \

--- a/src/consensus/addresses.h
+++ b/src/consensus/addresses.h
@@ -146,15 +146,15 @@ Consensus::CoinbaseAddresses AddressSets = {
         {
             "lotus_16PSJJYp3YkVyctW8LRbp6UhbsrQMJghL3jjze3b7",
         },
-    .judges = 
+    .judges =
         {
             "lotus_16PSJMaps9sQg7aBQgyY1RdHb2fZYdmWhQPbgus75"
         },
-    .ruth = 
+    .ruth =
         {
             "lotus_16PSJPi88MtH34Ti3dZza4MFRF9XUVd3fKc6Ec3TV"
         },
-    .firstSamuel = 
+    .firstSamuel =
         {
             "lotus_16PSJKi4ucDByLHn3mTQaBijiNZmczAdALVDGS53V"
         },
@@ -168,9 +168,7 @@ Consensus::CoinbaseAddresses AddressSets = {
     .firstKings =
         {
             // faithful turtle
-            "lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME",
-            // hash turtle
-            "lotus_16PSJMAVPBd6g7rYz9d3fw8BbENqNaPdU6wSi7eC8"
+            "lotus_16PSJQXrnTrUbhnxPpPgf1jd16JFkWk8TdbpALVME"
         },
 };
 } // namespace RewardAddresses

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1350,8 +1350,8 @@ void SetupServerArgs(NodeContext &node) {
 
 std::string LicenseInfo() {
     const std::string URL_SOURCE_CODE =
-        "<https://github.com/LogosFoundation/lotusd>";
-    const std::string URL_WEBSITE = "<https://www.givelotus.org>";
+        "<https://github.com/LotusiaStewardship/lotusd>";
+    const std::string URL_WEBSITE = "<https://www.lotusia.org>";
 
     return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009,
                                       COPYRIGHT_YEAR) +

--- a/src/minerfund.cpp
+++ b/src/minerfund.cpp
@@ -56,7 +56,7 @@ std::vector<CTxOut> GetMinerFundRequiredOutputs(const Consensus::Params &params,
         return {};
     }
 
-    // Revert to fan-out minerfund for First Kings (only two addresses)
+    // Revert to fan-out minerfund for First Kings (only one address)
     if (IsFirstKingsEnabled(params, pindexPrev)) {
         return BuildOutputsFanOut(params.coinbasePayoutAddresses.firstKings,
                                   pindexPrev, blockReward);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1859,7 +1859,12 @@ static void ThreadMapPort() {
     struct IGDdatas data;
     int r;
 
+#if MINIUPNPC_API_VERSION < 14
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    char wanaddr[64];
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), wanaddr, sizeof(wanaddr));
+#endif
     if (r == 1) {
         if (fDiscover) {
             char externalIPAddress[40];

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1859,7 +1859,7 @@ static void ThreadMapPort() {
     struct IGDdatas data;
     int r;
 
-#if MINIUPNPC_API_VERSION < 14
+#if MINIUPNPC_API_VERSION < 19
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
 #else
     char wanaddr[64];


### PR DESCRIPTION
 Drop the "hash turtle" address from the First Kings coinbase set,
 update project URLs in license info, and add a miniupnpc API version
 guard for cross-version compatibility.

 - consensus: remove the hash turtle coinbase address from the
   firstKings set; update minerfund fan-out comment to reflect
   single-address routing
 - init: replace source code and website URLs in LicenseInfo() with
   LotusiaStewardship/lotusd and lotusia.org
 - net: guard UPNP_GetValidIGD call with MINIUPNPC_API_VERSION to
   support both pre-v14 (2-arg) and v14+ (4-arg) signatures